### PR TITLE
Expose `IssueForm` to make custom issue form actions easier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.4.0...master
 
+### Added
+- Expose `IssueForm` to make custom issue form actions easier. Resolve [JPERF-450].
+
+[JPERF-450]: https://ecosystem.atlassian.net/browse/JPERF-450
+
 ## [3.4.0] - 2019-03-28
 [3.4.0]: https://github.com/atlassian/jira-actions/compare/release-3.3.0...release-3.4.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/EditIssuePage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/EditIssuePage.kt
@@ -1,6 +1,6 @@
 package com.atlassian.performance.tools.jiraactions.api.page
 
-import com.atlassian.performance.tools.jiraactions.page.form.IssueForm
+import com.atlassian.performance.tools.jiraactions.api.page.form.IssueForm
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.support.ui.ExpectedConditions.*

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/form/IssueForm.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/form/IssueForm.kt
@@ -1,23 +1,25 @@
-package com.atlassian.performance.tools.jiraactions.page.form
+package com.atlassian.performance.tools.jiraactions.api.page.form
 
 import com.atlassian.performance.tools.jiraactions.api.page.wait
+import com.atlassian.performance.tools.jiraactions.page.form.*
 import org.openqa.selenium.By
 import org.openqa.selenium.By.xpath
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.support.ui.ExpectedConditions
 import java.time.Duration
+import java.util.function.Supplier
 
-internal class IssueForm(
+class IssueForm(
     private val formLocator: By,
     private val driver: WebDriver
 ) {
     private val requiredFieldGroupsLocator = xpath("//span[contains(@class,'icon-required')]/ancestor::div[contains(@class,'field-group')]")
 
     fun <T> waitForRefresh(
-        action: () -> T
+        action: Supplier<T>
     ): T {
         val form = getForm()
-        val result = action()
+        val result = action.get()
         driver.wait(Duration.ofSeconds(30), ExpectedConditions.invisibilityOf(form))
         return result
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/IssueCreateDialog.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/IssueCreateDialog.kt
@@ -1,13 +1,14 @@
 package com.atlassian.performance.tools.jiraactions.page
 
 import com.atlassian.performance.tools.jiraactions.api.page.JiraErrors
+import com.atlassian.performance.tools.jiraactions.api.page.form.IssueForm
 import com.atlassian.performance.tools.jiraactions.api.page.tolerateDirtyFormsOnCurrentPage
 import com.atlassian.performance.tools.jiraactions.api.page.wait
-import com.atlassian.performance.tools.jiraactions.page.form.IssueForm
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.support.ui.ExpectedConditions.*
 import java.time.Duration
+import java.util.function.Supplier
 
 internal class IssueCreateDialog(
     private val driver: WebDriver
@@ -30,15 +31,15 @@ internal class IssueCreateDialog(
         return this
     }
 
-    fun selectProject(projectName: String) = form.waitForRefresh {
+    fun selectProject(projectName: String) = form.waitForRefresh(Supplier {
         projectField.select(projectName)
-        return@waitForRefresh this
-    }
+        return@Supplier this
+    })
 
-    fun selectIssueType(issueType: String) = form.waitForRefresh {
+    fun selectIssueType(issueType: String) = form.waitForRefresh(Supplier {
         issueTypeField.select(issueType)
-        return@waitForRefresh this
-    }
+        return@Supplier this
+    })
 
     fun getIssueTypes() = issueTypeField.getSuggestions()
         .plus(issueTypeField.getCurrentValue())


### PR DESCRIPTION
We're having some problems with our dataset. There's some problem with the "resolution" field.
We're exploring some workarounds, e.g.: https://github.com/kema2000/jira-actions/commit/72eefabbd15308fbf8c701693dba7f5079b7a564
However, we're forced to work on lib snapshots. I'd rather work on my custom `EditIssueAction`, which needs `EditIssuePage`, which needs `IssueForm`. The first two are very case-specific and can differ from dataset to dataset, so I don't expect them to be changed in `jira-actions`. However, copy-pasting `IssueForm` (along with all transitive internals) seems to be coutner-productive, because it contains pretty universal logic.
Therefore I want to expose it.