### PR TITLE
JPERF-207: Expose `WebJira.accessAdmin()`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.5.1...master
 
+### Added
+- Expose `WebJira.accessAdmin()`. Resolve [JPERF-207].
+
+[JPERF-207]: https://ecosystem.atlassian.net/browse/JPERF-207
+
 ## [3.5.1] - 2019-05-22
 [3.5.1]: https://github.com/atlassian/jira-actions/compare/release-3.5.0...release-3.5.1
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
@@ -19,13 +19,17 @@ data class WebJira(
 
     fun configureRichTextEditor(): RichTextEditorConfiguration {
         navigateTo("secure/admin/ConfigureRTE!default.jspa")
-        val access = AdminAccess(
-            driver = driver,
-            jira = this,
-            password = adminPassword
-        )
-        return RichTextEditorConfiguration(driver, access)
+        return RichTextEditorConfiguration(driver, accessAdmin())
     }
+
+    /**
+     * Also known as WebSudo.
+     */
+    fun accessAdmin() = AdminAccess(
+        driver = driver,
+        jira = this,
+        password = adminPassword
+    )
 
     fun goToSystemInfo() {
         navigateTo("secure/admin/ViewSystemInfo.jspa")


### PR DESCRIPTION
I finally found [the pretext](https://github.com/atlassian/jira-actions/pull/6/commits/7590ea9dc7c02e3ee679a0f4442687c9b3837169) to ship this trivial feature.