### PR TITLE
RUM-2812: spike JqlMemory change to categorize queries

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -47,6 +47,7 @@ dependencies {
     testCompile("com.atlassian.performance.tools:io:[1.0.0,2.0.0)")
     testCompile("com.atlassian.performance.tools:docker-infrastructure:0.1.2")
     testCompile("junit:junit:4.12")
+    testCompile("org.mockito:mockito-core:2.16.0")
 }
 
 tasks.test {

--- a/gradle/dependency-locks/compileClasspath.lockfile
+++ b/gradle/dependency-locks/compileClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.0.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/default.lockfile
+++ b/gradle/dependency-locks/default.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.0.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/implementationDependenciesMetadata.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.0.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/runtimeClasspath.lockfile
+++ b/gradle/dependency-locks/runtimeClasspath.lockfile
@@ -2,7 +2,7 @@
 # Manual edits can break the build and are not advised.
 # This file is expected to be part of source control.
 com.atlassian.performance.tools:concurrency:1.0.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
 com.google.code.gson:gson:2.8.2

--- a/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testApiDependenciesMetadata.lockfile
@@ -18,6 +18,7 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
+net.bytebuddy:byte-buddy-agent:1.7.9
 net.bytebuddy:byte-buddy:1.7.9
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -37,6 +38,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
+org.mockito:mockito-core:2.16.0
+org.objenesis:objenesis:2.6
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testCompile.lockfile
+++ b/gradle/dependency-locks/testCompile.lockfile
@@ -18,6 +18,7 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
+net.bytebuddy:byte-buddy-agent:1.7.9
 net.bytebuddy:byte-buddy:1.7.9
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -37,6 +38,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
+org.mockito:mockito-core:2.16.0
+org.objenesis:objenesis:2.6
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testCompileClasspath.lockfile
+++ b/gradle/dependency-locks/testCompileClasspath.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.0.0
 com.atlassian.performance.tools:docker-infrastructure:0.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
 com.google.code.gson:gson:2.8.2
@@ -16,6 +16,7 @@ com.squareup.okio:okio:1.13.0
 commons-codec:commons-codec:1.10
 commons-logging:commons-logging:1.2
 junit:junit:4.12
+net.bytebuddy:byte-buddy-agent:1.7.9
 net.bytebuddy:byte-buddy:1.7.9
 org.apache.commons:commons-exec:1.3
 org.apache.commons:commons-math3:3.6.1
@@ -37,6 +38,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
+org.mockito:mockito-core:2.16.0
+org.objenesis:objenesis:2.6
 org.seleniumhq.selenium:selenium-api:3.11.0
 org.seleniumhq.selenium:selenium-chrome-driver:3.11.0
 org.seleniumhq.selenium:selenium-remote-driver:3.11.0

--- a/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
+++ b/gradle/dependency-locks/testImplementationDependenciesMetadata.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.0.0
 com.atlassian.performance.tools:docker-infrastructure:0.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
 com.google.code.gson:gson:2.8.2
@@ -21,6 +21,7 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
+net.bytebuddy:byte-buddy-agent:1.7.9
 net.bytebuddy:byte-buddy:1.7.9
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -45,6 +46,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
+org.mockito:mockito-core:2.16.0
+org.objenesis:objenesis:2.6
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testRuntime.lockfile
+++ b/gradle/dependency-locks/testRuntime.lockfile
@@ -18,6 +18,7 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
+net.bytebuddy:byte-buddy-agent:1.7.9
 net.bytebuddy:byte-buddy:1.7.9
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -37,6 +38,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jdk7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jdk8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
+org.mockito:mockito-core:2.16.0
+org.objenesis:objenesis:2.6
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/gradle/dependency-locks/testRuntimeClasspath.lockfile
+++ b/gradle/dependency-locks/testRuntimeClasspath.lockfile
@@ -4,7 +4,7 @@
 com.atlassian.performance.tools:concurrency:1.0.0
 com.atlassian.performance.tools:docker-infrastructure:0.1.2
 com.atlassian.performance.tools:io:1.2.0
-com.atlassian.performance.tools:jvm-tasks:1.0.0
+com.atlassian.performance.tools:jvm-tasks:1.0.1
 com.github.stephenc.jcip:jcip-annotations:1.0-1
 com.google.code.findbugs:jsr305:1.3.9
 com.google.code.gson:gson:2.8.2
@@ -21,6 +21,7 @@ javax.activation:javax.activation-api:1.2.0
 javax.annotation:javax.annotation-api:1.3.2
 javax.xml.bind:jaxb-api:2.3.1
 junit:junit:4.12
+net.bytebuddy:byte-buddy-agent:1.7.9
 net.bytebuddy:byte-buddy:1.7.9
 net.java.dev.jna:jna-platform:5.2.0
 net.java.dev.jna:jna:5.2.0
@@ -45,6 +46,8 @@ org.jetbrains.kotlin:kotlin-stdlib-jre7:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib-jre8:1.2.70
 org.jetbrains.kotlin:kotlin-stdlib:1.2.70
 org.jetbrains:annotations:13.0
+org.mockito:mockito-core:2.16.0
+org.objenesis:objenesis:2.6
 org.rnorth.duct-tape:duct-tape:1.0.7
 org.rnorth.visible-assertions:visible-assertions:2.1.2
 org.rnorth:tcp-unix-socket-proxy:1.0.2

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/JqlMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/JqlMemory.kt
@@ -3,5 +3,10 @@ package com.atlassian.performance.tools.jiraactions.api.memories
 import com.atlassian.performance.tools.jiraactions.api.page.IssuePage
 
 interface JqlMemory : Memory<String> {
+
     fun observe(issuePage: IssuePage)
+
+    fun recall(filter: (String) -> Boolean): String? {
+        return null;
+    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/jql/BuiltInJQL.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/jql/BuiltInJQL.kt
@@ -1,0 +1,12 @@
+package com.atlassian.performance.tools.jiraactions.jql
+
+internal enum class BuiltInJQL {
+    GENERIC_WIDE,
+    RESOLVED,
+    PRIORITIES,
+    PROJECT,
+    ASSIGNEE,
+    REPORTERS,
+    PROJECT_ASSIGNEE,
+    GIVEN_WORD;
+}

--- a/src/test/kotlin/com/atlassian/performance/tools/jiraactions/api/JqlMemoryTest.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/jiraactions/api/JqlMemoryTest.kt
@@ -1,0 +1,41 @@
+package com.atlassian.performance.tools.jiraactions.api
+
+import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory
+import com.atlassian.performance.tools.jiraactions.api.page.IssuePage
+import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
+import org.assertj.core.api.Assertions
+import org.junit.Test
+import org.mockito.Mockito
+import org.mockito.stubbing.Answer
+import org.openqa.selenium.WebDriver
+
+class JqlMemoryTest {
+
+    @Test
+    fun expectPrioritiesJQL() {
+        val memory: JqlMemory = AdaptiveJqlMemory(SeededRandom());
+        val webdriverMock = Mockito.mock(WebDriver::class.java)
+        val issuePage: IssuePage = IssuePage(webdriverMock)
+        val issuePageSpy = Mockito.spy(issuePage)
+        Mockito.doAnswer(Answer { listOf("SMALL", "MIDDLE", "BIG", "HUGE") })
+            .`when`(issuePageSpy)
+            .getPossiblePriorities()
+        Mockito.doAnswer(Answer { null })
+            .`when`(issuePageSpy)
+            .getAssignee()
+        Mockito.doAnswer(Answer { null })
+            .`when`(issuePageSpy).getProject()
+        Mockito.doAnswer(Answer { null })
+            .`when`(issuePageSpy)
+            .visitReporterProfile()
+
+        memory.observe(issuePageSpy)
+        val jql = memory.recall { s -> BuiltInJQL.PRIORITIES.name == s }
+
+        Assertions.assertThat(jql)
+            .isNotNull()
+            .startsWith("priority in (")
+            .endsWith(") order by reporter")
+    }
+}

--- a/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
+++ b/src/test/resources/mockito-extensions/org.mockito.plugins.MockMaker
@@ -1,0 +1,1 @@
+mock-maker-inline


### PR DESCRIPTION
This pull request is for feedback only about API change. Do not focus on names  (for prescriptions keys) and other minor stuff.
Goal was to recall JQL from memory by some key/tag/category name