### PR TITLE
JPERF-522: Added recallByTag method JqlMemory (default) and implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,8 +28,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Added
 - Expose `WebJira.accessAdmin()`. Resolve [JPERF-207].
+- JqlMemory modified to allow recall queries by tag/query type. Resolve [JPERF-522].
 
 [JPERF-207]: https://ecosystem.atlassian.net/browse/JPERF-207
+[JPERF-522]: https://ecosystem.atlassian.net/browse/JPERF-522
 
 ## [3.5.1] - 2019-05-22
 [3.5.1]: https://github.com/atlassian/jira-actions/compare/release-3.5.0...release-3.5.1

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/JqlMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/JqlMemory.kt
@@ -1,7 +1,14 @@
 package com.atlassian.performance.tools.jiraactions.api.memories
 
 import com.atlassian.performance.tools.jiraactions.api.page.IssuePage
+import java.util.function.Predicate
 
 interface JqlMemory : Memory<String> {
+
     fun observe(issuePage: IssuePage)
+
+    @JvmDefault
+    fun recallByTag(filter: Predicate<String>): String? {
+        return null
+    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/adaptive/AdaptiveJqlMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/adaptive/AdaptiveJqlMemory.kt
@@ -5,8 +5,10 @@ import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.jql.JqlPrescription
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.jql.JqlPrescriptions
 import com.atlassian.performance.tools.jiraactions.api.page.IssuePage
+import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
+import java.util.function.Predicate
 
 class AdaptiveJqlMemory(
     private val random: SeededRandom
@@ -14,39 +16,50 @@ class AdaptiveJqlMemory(
 
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
+    companion object {
+        fun getAvailableTags(): List<String> = BuiltInJQL.values().map { it.name }.toList()
+    }
+
     private val jqls = mutableListOf(
-        "resolved is not empty order by description",
-        "text ~ \"a*\" order by summary"
+        TaggedBakedJql(BakedJql({ _ -> ""}, "resolved is not empty order by description"), BuiltInJQL.RESOLVED.name),
+        TaggedBakedJql(BakedJql({ _ -> ""}, "text ~ \"a*\" order by summary"), BuiltInJQL.GENERIC_WIDE.name)
     )
-    private val jqlPrescriptions = mutableSetOf(
-        JqlPrescriptions.prioritiesInEnumeratedList(random),
-        JqlPrescriptions.specifiedProject,
-        JqlPrescriptions.specifiedAssignee,
-        JqlPrescriptions.previousReporters,
-        JqlPrescriptions.specifiedAssigneeInSpecifiedProject,
-        JqlPrescriptions.filteredByGivenWord(random)
+
+    private val jqlPrescriptions = mutableMapOf(
+        BuiltInJQL.PRIORITIES.name to JqlPrescriptions.prioritiesInEnumeratedList(random),
+        BuiltInJQL.PROJECT.name to JqlPrescriptions.specifiedProject,
+        BuiltInJQL.ASSIGNEE.name to JqlPrescriptions.specifiedAssignee,
+        BuiltInJQL.REPORTERS.name to JqlPrescriptions.previousReporters,
+        BuiltInJQL.PROJECT_ASSIGNEE.name to JqlPrescriptions.specifiedAssigneeInSpecifiedProject,
+        BuiltInJQL.GIVEN_WORD.name to JqlPrescriptions.filteredByGivenWord(random)
     )
 
     override fun observe(issuePage: IssuePage) {
         val bakedJql = jqlPrescriptions.asSequence()
-            .map { BakedJql(it, it(issuePage)) }
-            .filter { it.jql != null }
+            .map { TaggedBakedJql(BakedJql(it.value, it.value(issuePage)), it.key) }
+            .filter { it.baked.jql != null }
             .firstOrNull()
 
         bakedJql?.let {
-            logger.debug("Rendered a new jql query: <<${it.jql!!}>>")
-            jqls.add(it.jql)
-            jqlPrescriptions.remove(it.jqlPrescription)
+            logger.debug("Rendered a new jql query: <<${it.baked.jql!!}>>")
+            jqls.add(it)
+            jqlPrescriptions.remove(it.tag)
         }
     }
 
     override fun recall(): String? {
-        return random.pick(jqls)
+        return random.pick(jqls)?.baked?.jql
     }
 
     override fun remember(memories: Collection<String>) {
-        jqls.addAll(memories)
+        jqls.addAll(memories.map { TaggedBakedJql(BakedJql({ _ -> ""}, it)) })
     }
+
+    override fun recallByTag(filter: Predicate<String>): String? {
+        return random.pick(jqls.filter {it.tag != null && filter.test(it.tag.toString()) }.toList())?.baked?.jql
+    }
+
+    private class TaggedBakedJql(val baked: BakedJql, val tag: String? = null)
 }
 
 data class BakedJql(

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/jql/BuiltInJQL.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/jql/BuiltInJQL.kt
@@ -1,0 +1,12 @@
+package com.atlassian.performance.tools.jiraactions.jql
+
+internal enum class BuiltInJQL {
+    GENERIC_WIDE,
+    RESOLVED,
+    PRIORITIES,
+    PROJECT,
+    ASSIGNEE,
+    REPORTERS,
+    PROJECT_ASSIGNEE,
+    GIVEN_WORD;
+}


### PR DESCRIPTION
Initial discussion was here https://github.com/atlassian/jira-actions/pull/16
This is not invasive change that provides ability to create SearchJql actions  with user selected JQLS