### PR TITLE
JPERF-652: Handle empty JQL memory in SearchJql* actions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.13.0...master
 
+### Fixed
+- Make JQL search actions gracefully handle empty JQL queries memory condition. Fix [JPERF-652].
+
+[JPERF-652]: https://ecosystem.atlassian.net/browse/JPERF-652
+
 ## [3.13.0] - 2020-05-26
 [3.13.0]: https://github.com/atlassian/jira-actions/compare/release-3.12.0...release-3.13.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
@@ -1,5 +1,6 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
+import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_WITH_JQL
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.WebJira
@@ -7,6 +8,8 @@ import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import javax.json.JsonObject
 
 class SearchJqlAction(
@@ -15,8 +18,14 @@ class SearchJqlAction(
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory
 ) : Action {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
     override fun run() {
-        val jqlQuery = jqlMemory.recall()!!
+        val jqlQuery = jqlMemory.recall()
+        if (jqlQuery == null) {
+            logger.debug("Skipping ${SEARCH_WITH_JQL.label} action. I have no knowledge of JQL queries.")
+            return
+        }
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_WITH_JQL,

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
@@ -8,6 +8,8 @@ import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObse
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import java.util.function.Predicate
 import javax.json.JsonObject
 
@@ -17,9 +19,15 @@ class SearchJqlChangelogAction(
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory
 ) : Action {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
 
     override fun run() {
-        val jqlQuery = jqlMemory.recallByTag(Predicate { it == BuiltInJQL.REPORTERS.name })!!
+        val jqlQuery = jqlMemory.recallByTag(Predicate { it == BuiltInJQL.REPORTERS.name })
+        if (jqlQuery == null) {
+            logger.debug("Skipping ${SEARCH_JQL_CHANGELOG.label} action. I have no knowledge of changelog-specific JQL queries.")
+            return
+        }
+
         val issueNavigatorPage = meter.measure(
             key = SEARCH_JQL_CHANGELOG,
             action = { jira.goToIssueNavigator(jqlQuery).waitForIssueNavigator() },

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
@@ -1,5 +1,6 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
+import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_SIMPLE
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
@@ -8,6 +9,8 @@ import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import java.util.function.Predicate
 import javax.json.JsonObject
 
@@ -17,8 +20,14 @@ class SearchJqlSimpleAction(
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory
 ) : Action {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
     override fun run() {
-        val jqlQueries = jqlMemory.recallByTag(Predicate { it != BuiltInJQL.GENERIC_WIDE.name && it != BuiltInJQL.REPORTERS.name })!!
+        val jqlQueries = jqlMemory.recallByTag(Predicate { it != BuiltInJQL.GENERIC_WIDE.name && it != BuiltInJQL.REPORTERS.name })
+        if (jqlQueries == null) {
+            logger.debug("Skipping ${SEARCH_JQL_SIMPLE.label} action. I have no knowledge of simple JQL queries.")
+            return
+        }
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_JQL_SIMPLE,

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlWildcardAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlWildcardAction.kt
@@ -1,5 +1,6 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
+import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_WITH_JQL_WILDCARD
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
@@ -8,6 +9,8 @@ import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
 import java.util.function.Predicate
 import javax.json.JsonObject
 
@@ -17,8 +20,14 @@ class SearchJqlWildcardAction(
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory
 ) : Action {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
     override fun run() {
-        val jqlQuery = jqlMemory.recallByTag(Predicate { it == BuiltInJQL.GENERIC_WIDE.name })!!
+        val jqlQuery = jqlMemory.recallByTag(Predicate { it == BuiltInJQL.GENERIC_WIDE.name })
+        if (jqlQuery == null) {
+            logger.debug("Skipping ${SEARCH_WITH_JQL_WILDCARD.label} action. I have no knowledge of wildcard JQL queries.")
+            return
+        }
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_WITH_JQL_WILDCARD,


### PR DESCRIPTION
Instead of throwing NPE, quite gracefully with debug log