### PR TITLE
JPERF-657: Fix Create Issue action to make it compatible with AUI 9

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
@@ -19,19 +19,27 @@ class IssueCreateDialog(
     private val projectField = SingleSelect(driver, By.id("project-field"))
     private val issueTypeField = SingleSelect(driver, By.id("issuetype-field"))
     private val configColumnField = By.id("qf-field-picker-trigger")
+    private val dialog = By.id("create-issue-dialog")
 
     fun waitForDialog(): IssueCreateDialog {
         val jiraErrors = JiraErrors(driver)
         driver.wait(
             timeout = Duration.ofSeconds(30),
             condition = or(
-                visibilityOfElementLocated(By.id("create-issue-dialog")),
+                visibilityOfElementLocated(dialog),
                 jiraErrors.anyCommonError()
             )
         )
         jiraErrors.assertNoErrors()
         driver.tolerateDirtyFormsOnCurrentPage()
         return this
+    }
+
+    private fun waitForDialogToHide() {
+        driver.wait(
+            timeout = Duration.ofSeconds(30),
+            condition = invisibilityOfElementLocated(dialog)
+        )
     }
 
     fun selectProject(projectName: String) = form.waitForRefresh(Supplier {
@@ -106,7 +114,7 @@ class IssueCreateDialog(
 
     fun submit() {
         driver.wait(elementToBeClickable(By.id("create-issue-submit"))).click()
-        driver.wait(Duration.ofSeconds(30), invisibilityOfElementLocated(By.className("aui-blanket")))
+        waitForDialogToHide()
     }
 
     private fun waitUntilSummaryIsFocused() {


### PR DESCRIPTION
AUI 9 changed the way aui-blanket visibility is switched during issue creation, so we cannot use it as a reliable, version-agnostic indicator that the action is finished. Let's use Create Issue dialog visibility instead.