### PR TITLE
JPERF-658: Refresh Jira versions list in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: java
 script: travis_wait 30 ./gradlew build
 
 env:
+  - JIRA_SOFTWARE_VERSION=8.13.0
+  - JIRA_SOFTWARE_VERSION=8.5.0
   - JIRA_SOFTWARE_VERSION=8.0.0
   - JIRA_SOFTWARE_VERSION=7.13.0
-  - JIRA_SOFTWARE_VERSION=7.3.0
   - JIRA_SOFTWARE_VERSION=7.2.0
 stages:
   - test


### PR DESCRIPTION
The list now includes: the oldest supported (7.2), LTS releases (7.13, 8.5, 8.13) and latest platform release (8.0)