### PR TITLE
CHER-277: Fixing getIssueKeys to work for Cloud environment for WorkOnSearch key experience when JPT runs tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .gradle
 build
+.idea/*

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
@@ -38,12 +38,20 @@ class IssueNavigatorPage(
         return this
     }
 
-    fun getIssueKeys(): Set<String> {
+    private fun getIssueKeys(cssSelector: String): Set<String> {
         val issueKeys: List<String> = JavaScriptUtils.executeScript(driver,
-            "return Array.from(document.getElementsByClassName('issue-link-key'), i => i.innerText.trim())"
+            "return Array.from(document.getElementsByClassName('${cssSelector}'), i => i.innerText.trim())"
         )
 
         return HashSet(issueKeys)
+    }
+
+    fun getIssueKeys(): Set<String> {
+        return getIssueKeys("issue-link-key")
+    }
+
+    fun getIssueKeysCloud(): Set<String> {
+        return getIssueKeys("issue-link")
     }
 
     fun issueView(): IssuePage {


### PR DESCRIPTION
Taking the following approach into action:
"Add an if/else statement in your code so that getIssueKeys() checks whether issue-link-key elements exist in the page and if not it checks if issue-link elements exist (which is the new name for those elements in cloud"
from the #help-jpt channel as we got an approval to create a PR for this work.