### PR TITLE
Making sure the summary field is being focused after project selection

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
@@ -152,9 +152,10 @@ class IssueCreateDialog(
     private fun elementIsFocused(locator: By): ExpectedCondition<WebElement?> {
         return object : ExpectedCondition<WebElement?> {
             override fun apply(driver: WebDriver?): WebElement? {
-                val summary = driver!!.findElement(locator)
-
-                return if (summary == driver.switchTo().activeElement()) summary else null
+                return elementToBeClickable(locator)
+                    .apply(driver)
+                    ?.also { it.click() }
+                    ?.takeIf { it == driver!!.switchTo().activeElement() }
             }
 
             override fun toString(): String {


### PR DESCRIPTION
The summary field is no longer being focused after recent accessibility changes we made in Jira 8.19. 
This PR removes the wait function as the field is not going to be focused. 

Backward compatibility is going to be present as the `fill` method invoked in `CreateIssueAction.kt` (defined in `IssueCreateDialog.kt`) relies on `sendKeysWhenClickable` which clicks on the element before sending keys, the click should focus the element out of the box. 

The wait function could be added in order to prevent race conditions but this should be eventually caught by the tests.
I am mentioning Przemek (@pbruski) as he introduced the change in the first place.