### PR TITLE
JPERF-730: Bump commons-codec, so that the module is compatible with …

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,7 @@ configurations.all {
         failOnVersionConflict()
         eachDependency {
             when (requested.module.toString()) {
-                "commons-codec:commons-codec" -> useVersion("1.10")
+                "commons-codec:commons-codec" -> useVersion("1.11")
                 "org.jetbrains:annotations" -> useVersion("13.0")
                 "org.slf4j:slf4j-api" -> useVersion("1.7.25")
                 "org.testcontainers:testcontainers" -> useVersion("1.15.1")


### PR DESCRIPTION
…recent versions of aws-resources (1.7.x)

Compatibility with aws-resources was broken with https://bitbucket.org/atlassian/aws-resources/commits/6e272c387f3dd60b44a0d4dfd019ae98b559a6a8 (version 1.6.1)

`commons-codec` bump to 1.11 needs to be done in multiple modules:
 * [jira-actions](https://github.com/atlassian/jira-actions)
 * [jira-software-actions](https://github.com/atlassian/jira-software-actions)
 * [virtual-users](https://github.com/atlassian/virtual-users)
 * [infrastructure](https://github.com/atlassian/infrastructure)
 * [aws-resources](https://bitbucket.org/atlassian/aws-resources)
 * [aws-infrastructure](https://github.com/atlassian/aws-infrastructure)

This PR will be followed by the rest from the list above.