### PR TITLE
Issue/mnstr 6059 implement new actions for activity tabs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,14 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.16.3...master
+### Added
+- Add new action View History Tab
+- Add new action View Comment
+- Add new page objects for Comment Tab Panel and History Tab Panel
+- Add `ViewIssueAction.Builder`
+- Extend `ViewIssueAction` with comment remembering capability
+- Add `CommentMemory`
+- Add new method to `WebJira` that allows visiting a comment
 
 ## [3.16.3] - 2022-04-08
 [3.16.3]: https://github.com/atlassian/jira-actions/compare/release-3.16.2...release-3.16.3

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ Edit Issue Submit   | While in Edit Issue Action: Press Submit → Wait for the 
 Add Comment         | Go to Add Comment for an issue form → Wait for form to load → Enter comment text → Press Submit → Wait for the summary on view issue page to show
 Add Comment Submit  | While in Add Comment Action: Press Submit → Wait for the summary on view issue page to show
 Browse Projects     | Go to Browse Projects Page → Wait for the project list to load
+View Comment        | Go to Comment Tab Panel located on View Issue Page → Wait until comment is focused
+View History Tab    | Go to History Tab Panel located on View Issue Page → Wait for all change history entries to load
 
 ## Reporting issues
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/ActionType.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/ActionType.kt
@@ -49,3 +49,5 @@ data class ActionType<out T>(
 @JvmField val VIEW_BOARD = ActionType("View Board") { IssuesOnBoard(it) }
 @JvmField val LOG_IN = ActionType("Log In") { Unit }
 @JvmField val SET_UP = ActionType("Set Up") { Unit }
+@JvmField val VIEW_COMMENT = ActionType("View Comment") { Unit }
+@JvmField val VIEW_HISTORY_TAB = ActionType("View History Tab") { IssueObservation(it) }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
@@ -22,7 +22,7 @@ data class WebJira(
         return RichTextEditorConfiguration(driver, accessAdmin())
     }
 
-    fun configureBackupPolicy() : BackupConfiguration {
+    fun configureBackupPolicy(): BackupConfiguration {
         navigateTo("secure/admin/ViewServices!default.jspa")
         return BackupConfiguration(driver, accessAdmin())
     }
@@ -92,6 +92,13 @@ data class WebJira(
 
     fun getJiraNode(): String {
         return driver.findElement(By.id("footer-build-information")).text
+    }
+
+    fun goToComment(
+        commentUrl: String
+    ): CommentTabPanel {
+        driver.navigate().to(commentUrl)
+        return CommentTabPanel(driver)
     }
 
     fun navigateTo(path: String) {

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewCommentAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewCommentAction.kt
@@ -1,0 +1,36 @@
+package com.atlassian.performance.tools.jiraactions.api.action
+
+import com.atlassian.performance.tools.jiraactions.api.VIEW_COMMENT
+import com.atlassian.performance.tools.jiraactions.api.WebJira
+import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
+import com.atlassian.performance.tools.jiraactions.api.memories.CommentMemory
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import javax.json.Json
+
+class ViewCommentAction(
+    private val jira: WebJira,
+    private val meter: ActionMeter,
+    private val commentMemory: CommentMemory
+) : Action {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    override fun run() {
+        val comment = commentMemory.recall()
+        if (comment == null) {
+            logger.debug("Skipping View Comment action. I have no knowledge of comments.")
+            return
+        }
+
+        meter.measure(
+            key = VIEW_COMMENT,
+            action = { jira.goToComment(comment.url).validateCommentIsFocused(comment.id) },
+            observation = { page ->
+                Json.createObjectBuilder()
+                    .add("issueKey", page.getIssueKey())
+                    .add("commentId", comment.id)
+                    .build()
+            }
+        )
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewHistoryTabAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewHistoryTabAction.kt
@@ -1,0 +1,32 @@
+package com.atlassian.performance.tools.jiraactions.api.action
+
+import com.atlassian.performance.tools.jiraactions.api.VIEW_HISTORY_TAB
+import com.atlassian.performance.tools.jiraactions.api.WebJira
+import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
+import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
+import com.atlassian.performance.tools.jiraactions.api.observation.IssueObservation
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+
+class ViewHistoryTabAction(
+    private val jira: WebJira,
+    private val meter: ActionMeter,
+    private val issueKeyMemory: IssueKeyMemory
+) : Action {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    override fun run() {
+        val issueKey = issueKeyMemory.recall()
+        if (issueKey == null) {
+            logger.debug("Skipping View History Tab action. I have no knowledge of issue keys.")
+            return
+        }
+
+        val page = jira.goToIssue(issueKey).waitForSummary()
+        meter.measure(
+            key = VIEW_HISTORY_TAB,
+            action = { page.openHistoryTabPanel().loadAllHistoryEntries() },
+            observation = { IssueObservation(issueKey).serialize() }
+        )
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewIssueAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewIssueAction.kt
@@ -3,25 +3,39 @@ package com.atlassian.performance.tools.jiraactions.api.action
 import com.atlassian.performance.tools.jiraactions.api.VIEW_ISSUE
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
-import com.atlassian.performance.tools.jiraactions.api.memories.Issue
-import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
-import com.atlassian.performance.tools.jiraactions.api.memories.IssueMemory
-import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.*
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import javax.json.Json
 
-class ViewIssueAction(
+class ViewIssueAction private constructor(
     private val jira: WebJira,
     private val meter: ActionMeter,
-    private val issueKeyMemory: IssueKeyMemory,
-    private val issueMemory: IssueMemory,
-    private val jqlMemory: JqlMemory
+    private val issueKeyMemory: IssueKeyMemory?,
+    private val issueMemory: IssueMemory?,
+    private val jqlMemory: JqlMemory?,
+    private val commentMemory: CommentMemory?
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
+    @Deprecated("Use ViewIssueAction.Builder instead.")
+    constructor(
+        jira: WebJira,
+        meter: ActionMeter,
+        issueKeyMemory: IssueKeyMemory?,
+        issueMemory: IssueMemory?,
+        jqlMemory: JqlMemory?
+    ) : this(
+        jira = jira,
+        meter = meter,
+        issueKeyMemory = issueKeyMemory,
+        issueMemory = issueMemory,
+        jqlMemory = jqlMemory,
+        commentMemory = null
+    )
+
     override fun run() {
-        val issueKey = issueKeyMemory.recall()
+        val issueKey = issueKeyMemory?.recall()
         if (issueKey == null) {
             logger.debug("Skipping View Issue action. I have no knowledge of issue keys.")
             return
@@ -29,10 +43,11 @@ class ViewIssueAction(
         val issuePage = meter.measure(
             key = VIEW_ISSUE,
             action = { jira.goToIssue(issueKey).waitForSummary() },
-            observation = { page -> Json.createObjectBuilder()
-                .add("issueKey", issueKey)
-                .add("issueId", page.getIssueId())
-                .build()
+            observation = { page ->
+                Json.createObjectBuilder()
+                    .add("issueKey", issueKey)
+                    .add("issueId", page.getIssueId())
+                    .build()
             }
         )
         val issue = Issue(
@@ -41,7 +56,38 @@ class ViewIssueAction(
             id = issuePage.getIssueId(),
             type = issuePage.getIssueType()
         )
-        issueMemory.remember(setOf(issue))
-        jqlMemory.observe(issuePage)
+        val comments = issuePage.openCommentTabPanel()
+            .showAllComments()
+            .getComments()
+
+        issueMemory?.remember(setOf(issue))
+        commentMemory?.remember(comments)
+        jqlMemory?.observe(issuePage)
+    }
+
+    class Builder(
+        private var jira: WebJira,
+        private var meter: ActionMeter
+    ) {
+        private var issueKeyMemory: IssueKeyMemory? = null
+        private var issueMemory: IssueMemory? = null
+        private var jqlMemory: JqlMemory? = null
+        private var commentMemory: CommentMemory? = null
+
+        fun webJira(jira: WebJira) = apply { this.jira = jira }
+        fun meter(meter: ActionMeter) = apply { this.meter = meter }
+        fun issueKeyMemory(issueKeyMemory: IssueKeyMemory) = apply { this.issueKeyMemory = issueKeyMemory }
+        fun issueMemory(issueMemory: IssueMemory) = apply { this.issueMemory = issueMemory }
+        fun jqlMemory(jqlMemory: JqlMemory) = apply { this.jqlMemory = jqlMemory }
+        fun commentMemory(commentMemory: CommentMemory) = apply { this.commentMemory = commentMemory }
+
+        fun build() = ViewIssueAction(
+            jira = jira,
+            meter = meter,
+            issueKeyMemory = issueKeyMemory,
+            issueMemory = issueMemory,
+            jqlMemory = jqlMemory,
+            commentMemory = commentMemory
+        )
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/Comment.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/Comment.kt
@@ -1,0 +1,24 @@
+package com.atlassian.performance.tools.jiraactions.api.memories
+
+class Comment(
+    val id: String,
+    val url: String
+) {
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as Comment
+
+        if (id != other.id) return false
+        if (url != other.url) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int {
+        var result = id.hashCode()
+        result = 31 * result + url.hashCode()
+        return result
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/CommentMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/CommentMemory.kt
@@ -1,0 +1,3 @@
+package com.atlassian.performance.tools.jiraactions.api.memories
+
+interface CommentMemory : Memory<Comment>

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/adaptive/AdaptiveCommentMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/adaptive/AdaptiveCommentMemory.kt
@@ -1,0 +1,22 @@
+package com.atlassian.performance.tools.jiraactions.api.memories.adaptive
+
+import com.atlassian.performance.tools.jiraactions.api.SeededRandom
+import com.atlassian.performance.tools.jiraactions.api.memories.Comment
+import com.atlassian.performance.tools.jiraactions.api.memories.CommentMemory
+
+class AdaptiveCommentMemory(
+    private val random: SeededRandom
+) : CommentMemory {
+    private val comments = mutableSetOf<Comment>()
+
+    override fun recall(): Comment? {
+        if (comments.isEmpty()) {
+            return null
+        }
+        return random.pick(comments.toList())
+    }
+
+    override fun remember(memories: Collection<Comment>) {
+        comments.addAll(memories)
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/CommentTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/CommentTabPanel.kt
@@ -1,0 +1,96 @@
+package com.atlassian.performance.tools.jiraactions.api.page
+
+import com.atlassian.performance.tools.jiraactions.api.memories.Comment
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import org.openqa.selenium.By
+import org.openqa.selenium.Keys
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.interactions.Actions
+import org.openqa.selenium.support.ui.ExpectedConditions
+import java.time.Duration
+
+class CommentTabPanel(
+    val driver: WebDriver
+) {
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    private val loadMoreCommentsJira8Locator: By = By.cssSelector("a.show-more-comments")
+    private val loadMoreCommentsJira9Locator: By = By.cssSelector("button.show-more-comment-tabpanel")
+
+    fun waitForActive(): CommentTabPanel {
+        driver.wait(
+            Duration.ofSeconds(45),
+            ExpectedConditions.elementToBeClickable(By.id("comment-tabpanel"))
+        ).click()
+        driver.wait(
+            Duration.ofSeconds(60),
+            ExpectedConditions.presenceOfElementLocated(By.cssSelector("#comment-tabpanel.active-tab"))
+        )
+        return this
+    }
+
+    fun getComments(): Set<Comment> {
+        val comments = driver.findElements(By.cssSelector("#issue_actions_container > div.activity-comment"))
+        return comments.map {
+            val id = it.getAttribute("id").split("-")[1]
+            val url = it.findElement(By.cssSelector(".comment-created-date-link")).getAttribute("href")
+            Comment(id, url)
+        }.toSet()
+    }
+
+    fun validateCommentIsFocused(
+        commentId: String
+    ): CommentTabPanel {
+        driver.wait(
+            Duration.ofSeconds(30),
+            ExpectedConditions.visibilityOfElementLocated(By.cssSelector("#comment-$commentId.focused"))
+        )
+        return this
+    }
+
+    fun getIssueKey(): String = driver.findElement(By.cssSelector("a.issue-link")).getAttribute("data-issue-key")
+
+    fun showAllComments(): CommentTabPanel {
+        if (driver.isElementPresent(loadMoreCommentsJira8Locator)) {
+            return showAllCommentsInJira8()
+        } else if (driver.isElementPresent(loadMoreCommentsJira9Locator)) {
+            return showAllCommentsInJira9()
+        } else {
+            logger.debug("This Jira version is not supported.")
+        }
+        return this
+    }
+
+    private fun showAllCommentsInJira8(): CommentTabPanel {
+        val loadMoreButton = driver.findElement(loadMoreCommentsJira8Locator)
+        loadMoreButton.click()
+        driver.wait(
+            timeout = Duration.ofSeconds(60),
+            condition = ExpectedConditions.stalenessOf(loadMoreButton)
+        )
+        return this
+    }
+
+    private fun showAllCommentsInJira9(): CommentTabPanel {
+        driver.findElement(loadMoreCommentsJira9Locator).click()
+
+        if (driver.isElementPresent(loadMoreCommentsJira8Locator) && driver.findElement(loadMoreCommentsJira9Locator)
+                .getAttribute("data-load-all-enabled").equals("true")
+        ) {
+            val loadMoreButton = driver.findElement(loadMoreCommentsJira9Locator)
+
+            Actions(driver)
+                .keyDown(Keys.SHIFT)
+                .click(loadMoreButton)
+                .keyUp(Keys.SHIFT)
+                .build()
+                .perform()
+            driver.wait(
+                timeout = Duration.ofSeconds(60),
+                condition = ExpectedConditions.stalenessOf(loadMoreButton)
+            )
+        }
+        return this
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
@@ -1,0 +1,41 @@
+package com.atlassian.performance.tools.jiraactions.api.page
+
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.ExpectedConditions
+import java.time.Duration
+
+class HistoryTabPanel(
+    private val driver: WebDriver
+) {
+    private val loadMoreEntriesLocator = By.cssSelector("button.show-more-changehistory-tabpanel")
+
+    fun loadAllHistoryEntries(): HistoryTabPanel {
+        if (driver.isElementPresent(loadMoreEntriesLocator)) {
+            val loadMoreButton = driver.findElement(loadMoreEntriesLocator)
+            loadMoreButton.click()
+            driver.wait(
+                timeout = Duration.ofSeconds(60),
+                condition = ExpectedConditions.stalenessOf(loadMoreButton)
+            )
+        } else {
+            driver.wait(
+                timeout = Duration.ofSeconds(60),
+                condition = ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(".issuePanelWrapper.loading"))
+            )
+        }
+        return this
+    }
+
+    fun waitForActive(): HistoryTabPanel {
+        driver.wait(
+            Duration.ofSeconds(45),
+            ExpectedConditions.elementToBeClickable(By.id("changehistory-tabpanel"))
+        ).click()
+        driver.wait(
+            Duration.ofSeconds(60),
+            ExpectedConditions.presenceOfElementLocated(By.cssSelector("#changehistory-tabpanel.active-tab"))
+        )
+        return this
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssuePage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssuePage.kt
@@ -82,4 +82,12 @@ class IssuePage(
 
     fun getIssueId(): Long = driver.findElement(By.id("key-val")).getAttribute("rel").toLong()
     fun getIssueType(): String = driver.findElement(By.id("type-val")).text
+
+    fun openCommentTabPanel(): CommentTabPanel {
+        return CommentTabPanel(driver).waitForActive()
+    }
+
+    fun openHistoryTabPanel(): HistoryTabPanel {
+        return HistoryTabPanel(driver).waitForActive()
+    }
 }

--- a/src/test/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/RichTextEditorIT.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/RichTextEditorIT.kt
@@ -11,10 +11,7 @@ import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.measure.output.CollectionActionMetricOutput
 import com.atlassian.performance.tools.jiraactions.api.memories.User
 import com.atlassian.performance.tools.jiraactions.api.memories.UserMemory
-import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveIssueKeyMemory
-import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveIssueMemory
-import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory
-import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveProjectMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.*
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.assertj.core.api.Assertions
@@ -96,6 +93,7 @@ class JiraEditScenario : Scenario {
         val jqlMemory = AdaptiveJqlMemory(seededRandom)
         val issueKeyMemory = AdaptiveIssueKeyMemory(random = seededRandom)
         val issueMemory = AdaptiveIssueMemory(issueKeyMemory, seededRandom)
+        val commentMemory = AdaptiveCommentMemory(seededRandom)
 
         val createIssue = CreateIssueAction(
             jira = jira,
@@ -109,13 +107,13 @@ class JiraEditScenario : Scenario {
             jqlMemory = jqlMemory,
             issueKeyMemory = issueKeyMemory
         )
-        val viewIssue = ViewIssueAction(
-            jira = jira,
-            meter = meter,
-            issueKeyMemory = issueKeyMemory,
-            issueMemory = issueMemory,
-            jqlMemory = jqlMemory
-        )
+        val viewIssue = ViewIssueAction.Builder(jira, meter)
+            .issueKeyMemory(issueKeyMemory)
+            .issueMemory(issueMemory)
+            .jqlMemory(jqlMemory)
+            .commentMemory(commentMemory)
+            .build()
+
         val editIssue = EditIssueAction(
             jira = jira,
             meter = meter,


### PR DESCRIPTION
This PR introduces two new actions for Jira: VIEW_FOCUSED_COMMENT and VIEW_HISTORY_TAB.

Because of significant differences between Tab Panel in Jira 8 and Jira 9 I had to implements two paths for those actions.
 - Focused comment - I added a new memory for comments, and to populate it I added exploring comments as a part of VIEW_ISSUE action.
The exploring part for Jira 9 is a bit more complex than in Jira 8 as the button to load more at the beginning allows only to load 10 more comments, and later, after first click, ability to load all the rest of comments is unlocked. In Jira 8 one click on the buton loads all comments at once.
- History tab - here we only wait for all entries to be loaded, but on Jira 8 all entries appear instantly, on Jira 9 only 10 entries are available right after switching to this tab, the rest has to be fetched by clicking on the button. 
