### PR TITLE
MNSTR-6059 Fix View History Tab Action by loading all entries in J9. …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.17.0...master
+### Fixed
+- Show all history entries in Jira 9.x
+- Use proper locator when exploring comments in Jira 9
+- Increase the waiting time when looking for presence of DOM elements in `ViewHistoryTabAction` and `ViewCommentAction`
 
 ## [3.17.0] - 2022-05-20
 [3.17.0]: https://github.com/atlassian/jira-actions/compare/release-3.16.3...release-3.17.0

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewHistoryTabAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/ViewHistoryTabAction.kt
@@ -25,7 +25,7 @@ class ViewHistoryTabAction(
         val page = jira.goToIssue(issueKey).waitForSummary()
         meter.measure(
             key = VIEW_HISTORY_TAB,
-            action = { page.openHistoryTabPanel().loadAllHistoryEntries() },
+            action = { page.openHistoryTabPanel().showAllHistoryEntries() },
             observation = { IssueObservation(issueKey).serialize() }
         )
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
@@ -1,41 +1,61 @@
 package com.atlassian.performance.tools.jiraactions.api.page
 
 import org.openqa.selenium.By
+import org.openqa.selenium.Keys
 import org.openqa.selenium.WebDriver
+import org.openqa.selenium.interactions.Actions
 import org.openqa.selenium.support.ui.ExpectedConditions
 import java.time.Duration
 
 class HistoryTabPanel(
     private val driver: WebDriver
 ) {
+    // the duration is set to such value because viewing issue with many change history entries is a heavy operation,
+    // and we assume the user is patient enough to wait for all entries to show up
+    private val duration: Duration = Duration.ofMinutes(2)
     private val loadMoreEntriesLocator = By.cssSelector("button.show-more-changehistory-tabpanel")
+    private val attemptLimit = 5
 
-    fun loadAllHistoryEntries(): HistoryTabPanel {
+    fun showAllHistoryEntries(): HistoryTabPanel {
         if (driver.isElementPresent(loadMoreEntriesLocator)) {
-            val loadMoreButton = driver.findElement(loadMoreEntriesLocator)
-            loadMoreButton.click()
-            driver.wait(
-                timeout = Duration.ofSeconds(60),
-                condition = ExpectedConditions.stalenessOf(loadMoreButton)
-            )
-        } else {
-            driver.wait(
-                timeout = Duration.ofSeconds(60),
-                condition = ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(".issuePanelWrapper.loading"))
-            )
+            return showMoreEntriesIfNeeded()
         }
+        driver.wait(
+            duration,
+            ExpectedConditions.invisibilityOfElementLocated(By.cssSelector(".issuePanelWrapper.loading"))
+        )
         return this
     }
 
     fun waitForActive(): HistoryTabPanel {
         driver.wait(
-            Duration.ofSeconds(45),
+            duration,
             ExpectedConditions.elementToBeClickable(By.id("changehistory-tabpanel"))
         ).click()
         driver.wait(
-            Duration.ofSeconds(60),
+            duration,
             ExpectedConditions.presenceOfElementLocated(By.cssSelector("#changehistory-tabpanel.active-tab"))
         )
+        return this
+    }
+
+    private fun showMoreEntriesIfNeeded(): HistoryTabPanel {
+        repeat(attemptLimit) {
+            if (!driver.isElementPresent(loadMoreEntriesLocator)) {
+                return this
+            }
+            val loadMoreButton = driver.findElement(loadMoreEntriesLocator)
+            Actions(driver)
+                .keyDown(Keys.SHIFT)
+                .click(loadMoreButton)
+                .keyUp(Keys.SHIFT)
+                .build()
+                .perform()
+            driver.wait(
+                duration,
+                ExpectedConditions.stalenessOf(loadMoreButton)
+            )
+        }
         return this
     }
 }


### PR DESCRIPTION
In this PR I'm fixing issues with recently added actions: ViewHistoryTab and ViewComment.

View History Tab Action:
- in Jira 9 only the first batch of entries was loaded after clicking on 'show more' button, later the presence of the button was ignored. After fix clicking on 'show more' button is handled in the loop,
- in Jira 8 in some cases previously set duration was not enough to finish loading the entries. I increased it for all timed conditions to avoid timeout exceptions.

View Comment Action:
- improper selector was used in the function responsible for loading all comments in Jira 9,
- the previous logic for loading comments in Jira 9 was replaced with the same solution as for View History Tab - clicking 'show more' button in the loop,
- I increased the time duration in timed condition similarly as for View History Tab Action.