### PR TITLE
JPERF-903 Open NotificationPopUps class to make it accessible from other JPT related libraries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.17.3...master
 
+### Changed
+- Remove `internal` modifier from `NotificationPopUps`. Unblock [JPERF-903]
+
 ## [3.17.3] - 2022-10-19
 [3.17.3]: https://github.com/atlassian/jira-actions/compare/release-3.17.2...release-3.17.3
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/DashboardPage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/DashboardPage.kt
@@ -1,6 +1,5 @@
 package com.atlassian.performance.tools.jiraactions.api.page
 
-import com.atlassian.performance.tools.jiraactions.page.NotificationPopUps
 import org.openqa.selenium.By
 import org.openqa.selenium.JavascriptExecutor
 import org.openqa.selenium.WebDriver

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
@@ -2,7 +2,6 @@ package com.atlassian.performance.tools.jiraactions.api.page
 
 import com.atlassian.performance.tools.jiraactions.api.page.form.IssueForm
 import com.atlassian.performance.tools.jiraactions.api.webdriver.sendKeysWhenClickable
-import com.atlassian.performance.tools.jiraactions.page.NotificationPopUps
 import com.atlassian.performance.tools.jiraactions.page.SingleSelect
 import org.openqa.selenium.*
 import org.openqa.selenium.support.ui.ExpectedCondition

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/NotificationPopUps.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/NotificationPopUps.kt
@@ -1,6 +1,5 @@
-package com.atlassian.performance.tools.jiraactions.page
+package com.atlassian.performance.tools.jiraactions.api.page
 
-import com.atlassian.performance.tools.jiraactions.api.page.wait
 import com.atlassian.performance.tools.jiraactions.api.webdriver.JavaScriptUtils
 import org.openqa.selenium.By
 import org.openqa.selenium.TimeoutException
@@ -9,7 +8,7 @@ import org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfElementLo
 import java.time.Duration
 
 
-internal class NotificationPopUps(private val driver: WebDriver) {
+class NotificationPopUps(private val driver: WebDriver) {
     private val auiFlagCloseLocator = By.cssSelector(".aui-flag .icon-close, .aui-flag .aui-close-button")
 
     fun dismissHealthCheckNotifications() : NotificationPopUps {


### PR DESCRIPTION
To fix the flakiness of `edit sprint` action defined in `jira-software-actions` module I needed a way to close AUI flags. The mechanism for that was already implemented in this module however, `NotificationPopUps` was defined as an internal class. To make it possible to use this class in `jira-software-action` and avoid code duplication I removed that modifier.