### PR TITLE
JPERF-967: Ignore alerts in `BackupConfiguration`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.18.0...master
 
+### Fixed
+- Tolerate dirty form warnings in `BackupConfiguration`. Fix [JPERF-967].
+
+[JPERF-967]: https://ecosystem.atlassian.net/browse/JPERF-967
+
 ## [3.18.0] - 2022-12-15
 [3.18.0]: https://github.com/atlassian/jira-actions/compare/release-3.17.3...release-3.18.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/BackupConfiguration.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/BackupConfiguration.kt
@@ -2,7 +2,6 @@ package com.atlassian.performance.tools.jiraactions.api.page
 
 import org.apache.logging.log4j.LogManager
 import org.openqa.selenium.By
-import org.openqa.selenium.TimeoutException
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.support.ui.ExpectedConditions
 
@@ -24,6 +23,7 @@ class BackupConfiguration(
         if (prompted) {
             access.gain()
         }
+        driver.tolerateDirtyFormsOnCurrentPage()
         while (driver.isElementPresent(deleteBackupLocator)) {
             deleteBackupService()
         }
@@ -36,12 +36,7 @@ class BackupConfiguration(
 
     private fun deleteBackupService() {
         driver.wait(ExpectedConditions.elementToBeClickable(deleteBackupLocator)).click()
-        try {
-            driver.wait(ExpectedConditions.alertIsPresent())
-            driver.switchTo().alert().accept()
-        } catch (e: TimeoutException) {
-            //this alert sometimes doesn't show...
-        }
+        driver.tolerateDirtyFormsOnCurrentPage()
         if (access.isPrompted()) {
             access.gain()
         }

--- a/src/test/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/AbstractJiraCoreScenario.kt
+++ b/src/test/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/AbstractJiraCoreScenario.kt
@@ -8,6 +8,7 @@ import com.atlassian.performance.tools.jiraactions.api.measure.output.Collection
 import com.atlassian.performance.tools.jiraactions.api.memories.User
 import com.atlassian.performance.tools.jiraactions.api.memories.UserMemory
 import com.atlassian.performance.tools.jiraactions.api.page.isElementPresent
+import com.atlassian.performance.tools.jiraactions.api.page.tolerateDirtyFormsOnCurrentPage
 import com.atlassian.performance.tools.jiraactions.api.w3c.JavascriptW3cPerformanceTimeline
 import com.atlassian.performance.tools.jiraactions.api.webdriver.sendKeysAndValidate
 import org.apache.logging.log4j.LogManager
@@ -107,6 +108,7 @@ abstract class AbstractJiraCoreScenario {
             driver.findElementById("login-form-authenticatePassword").sendKeys("admin")
             driver.findElement(By.id("login-form-submit")).click()
         }
+        driver.tolerateDirtyFormsOnCurrentPage()
     }
 
     private fun addBackupService(driver: RemoteWebDriver) {


### PR DESCRIPTION
The "services" page is overly sensitive to user input. On load, it focuses an input and even if you don't type anything, the mere act of losing focus from the input is considered as user input.

This fixes errors like:
```
Exception in thread "main" java.lang.Exception: Failed to run with [--jira-address, http://54.196.167.17:8080/, --login, admin, --password, 59c98750-ed37-4b27-a6d4-beebbcc6c029, --virtual-users, 20, --logging, com.atlassian.jira.test.performance.logging.TraceLogger, --hold, PT0S, --ramp, PT15S, --flat, PT10M, --max-overall-load, 300.0/PT1M, --scenario, com.atlassian.jira.test.performance.scenario.AllActionScenario, --diagnostics-limit, 64, --seed, 18, --browser, com.atlassian.jira.test.performance.browser.CustomChromeBrowser, --user-generator, com.atlassian.performance.tools.virtualusers.api.users.SuppliedUserGenerator]
	at com.atlassian.performance.tools.virtualusers.api.Application.tryRunning(EntryPoint.kt:31)
	at com.atlassian.performance.tools.virtualusers.api.EntryPointKt.main(EntryPoint.kt:18)
Caused by: java.lang.Exception: Failed to run com.atlassian.jira.test.performance.action.SetupActionWithoutBackupService@16414e40
	at com.atlassian.performance.tools.virtualusers.ExploratoryVirtualUser.runWithDiagnostics(ExploratoryVirtualUser.kt:83)
	at com.atlassian.performance.tools.virtualusers.ExploratoryVirtualUser.setUpJira(ExploratoryVirtualUser.kt:33)
	at com.atlassian.performance.tools.virtualusers.LoadTest.setUpJira(LoadTest.kt:103)
	at com.atlassian.performance.tools.virtualusers.LoadTest.run(LoadTest.kt:64)
	at com.atlassian.performance.tools.virtualusers.api.Application.run(EntryPoint.kt:44)
	at com.atlassian.performance.tools.virtualusers.api.Application.tryRunning(EntryPoint.kt:27)
	... 1 more
Caused by: java.lang.Exception: Action 'Set Up' ERROR
	at com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter.measure(ActionMeter.kt:134)
	at com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter.measure(ActionMeter.kt:84)
	at com.atlassian.jira.test.performance.action.SetupActionWithoutBackupService.run(SetupActions.kt:13)
	at com.atlassian.performance.tools.virtualusers.ExploratoryVirtualUser.runWithDiagnostics(ExploratoryVirtualUser.kt:80)
	... 6 more
Caused by: org.openqa.selenium.UnhandledAlertException: unexpected alert open: {Alert text : }
  (Session info: headless chrome=109.0.5414.119): {Alert text :
Build info: version: 'unknown', revision: 'unknown', time: 'unknown'
System info: host: 'ip-10-0-0-73', ip: '10.0.0.73', os.name: 'Linux', os.arch: 'amd64', os.version: '5.13.0-1029-aws', java.version: '1.8.0_352'
Driver info: org.openqa.selenium.chrome.ChromeDriver
Capabilities {acceptInsecureCerts: false, browserName: chrome, browserVersion: 109.0.5414.119, chrome: {chromedriverVersion: 109.0.5414.74 (e7c5703604da..., userDataDir: /tmp/.com.google.Chrome.NAdtnw}, goog:chromeOptions: {debuggerAddress: localhost:39611}, javascriptEnabled: true, networkConnectionEnabled: false, pageLoadStrategy: eager, platform: LINUX, platformName: LINUX, proxy: Proxy(), setWindowRect: true, strictFileInteractability: false, timeouts: {implicit: 0, pageLoad: 300000, script: 30000}, unhandledPromptBehavior: dismiss and notify, webauthn:extension:credBlob: true, webauthn:extension:largeBlob: true, webauthn:virtualAuthenticators: true}
Session ID: 417d3f2281647046acfbf110cf862a5c
*** Element info: {Using=class name, value=page-type-dashboard}
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:120)
	at org.openqa.selenium.remote.http.W3CHttpResponseCodec.decode(W3CHttpResponseCodec.java:49)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:158)
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:83)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:552)
	at org.openqa.selenium.remote.RemoteWebDriver.findElement(RemoteWebDriver.java:323)
	at org.openqa.selenium.remote.RemoteWebDriver.findElementByClassName(RemoteWebDriver.java:412)
	at org.openqa.selenium.By$ByClassName.findElement(By.java:389)
	at org.openqa.selenium.remote.RemoteWebDriver.findElement(RemoteWebDriver.java:315)
	at org.openqa.selenium.support.ui.ExpectedConditions$6.apply(ExpectedConditions.java:182)
	at org.openqa.selenium.support.ui.ExpectedConditions$6.apply(ExpectedConditions.java:179)
	at org.openqa.selenium.support.ui.ExpectedConditions$48.apply(ExpectedConditions.java:1413)
	at org.openqa.selenium.support.ui.ExpectedConditions$48.apply(ExpectedConditions.java:1409)
	at org.openqa.selenium.support.ui.ExpectedConditions$47.apply(ExpectedConditions.java:1370)
	at org.openqa.selenium.support.ui.ExpectedConditions$47.apply(ExpectedConditions.java:1364)
	at org.openqa.selenium.support.ui.FluentWait.until(FluentWait.java:249)
	at com.atlassian.performance.tools.jiraactions.api.page.WebDriverUtils.wait(WebDriverExtension.kt:27)
	at com.atlassian.performance.tools.jiraactions.api.page.WebDriverUtils.wait$default(WebDriverExtension.kt:21)
	at com.atlassian.performance.tools.jiraactions.api.page.DashboardPage.waitForDashboard(DashboardPage.kt:25)
	at com.atlassian.performance.tools.jiraactions.api.page.AdminAccess.drop(AdminAccess.kt:66)
	at com.atlassian.performance.tools.jiraactions.api.page.BackupConfiguration.delete(BackupConfiguration.kt:32)
	at com.atlassian.jira.test.performance.action.SetupActionWithoutBackupService$run$1.invoke(SetupActions.kt:15)
	at com.atlassian.jira.test.performance.action.SetupActionWithoutBackupService$run$1.invoke(SetupActions.kt:13)
	at com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter.measure(ActionMeter.kt:107)
	... 9 more
```