### PR TITLE
JPERF-1043 Add support for list view on IssueNavigatorPage. Add Issue…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,16 @@ Dropping a requirement of a major version of a dependency is a new contract.
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.18.1...master
 
 ### Added
-- Support both list view and detail view in `IssueNavigatorPage`. Fix [JPERF-1043].
-- Add `IssueNavigatorPage.View` parameter to JQL actions constructors.
+- Support `ListView`, `DetailView` and other possible `IssueNavResultsView`s. Fix [JPERF-1043].
+- Add `IssueNavResultsView` parameter to JQL actions constructors.
+
+### Deprecated
+- Deprecate most methods of `IssueNavigatorPage`,
+  because they implicitly assumed `DetailView`, which won't work on `ListView`.
 
 ### Fixed
 - Disable instance health notifications in `SetUpAction`. Fix [JPERF-1050].
-- Randomly pick between list view and detail view in `JiraCoreScenario`.
+- Randomly pick between `ListView` and `DetailView` in `JiraCoreScenario`.
 
 [JPERF-1050]: https://ecosystem.atlassian.net/browse/JPERF-1050
 [JPERF-1043]: https://ecosystem.atlassian.net/browse/JPERF-1043

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,12 +27,17 @@ Dropping a requirement of a major version of a dependency is a new contract.
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.18.1...master
 
 ### Added
-- Support `ListView`, `DetailView` and other possible `IssueNavResultsView`s. Fix [JPERF-1043].
-- Add `IssueNavResultsView` parameter to JQL actions constructors.
+- Support `ListView`, `DetailView` and other possible `IssueNavResultsView`s.
+- Add `SearchIssues` action, which supports various `IssueNavResultsView`s. Fix [JPERF-1043].
 
 ### Deprecated
 - Deprecate most methods of `IssueNavigatorPage`,
   because they implicitly assumed `DetailView`, which won't work on `ListView`.
+- Deprecate all copies of `SearchJqlAction` (in favour of `SearchIssues`):
+  - `SearchJqlAction` itself
+  - `SearchJqlChangelogAction`
+  - `SearchJqlSimpleAction`
+  - `SearchJqlWildcardAction`
 
 ### Fixed
 - Disable instance health notifications in `SetUpAction`. Fix [JPERF-1050].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,7 +28,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 ### Added
 - Support both list view and detail view in `IssueNavigatorPage`. Fix [JPERF-1043].
-- Add `IssueNavigatorView` parameter to JQL actions constructors.
+- Add `IssueNavigatorPage.View` parameter to JQL actions constructors.
 
 ### Fixed
 - Disable instance health notifications in `SetUpAction`. Fix [JPERF-1050].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,15 +27,15 @@ Dropping a requirement of a major version of a dependency is a new contract.
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.18.1...master
 
 ### Added
-- Add optional `IssueNavigatorView` parameter to JQL actions constructors. Make `IssueNavigationPage` support both list view and split view. Fix [JPERF-1043].
+- Support both list view and detail view in `IssueNavigatorPage`. Fix [JPERF-1043].
+- Add `IssueNavigatorView` parameter to JQL actions constructors.
 
 ### Fixed
 - Disable instance health notifications in `SetUpAction`. Fix [JPERF-1050].
+- Randomly pick between list view and detail view in `JiraCoreScenario`.
 
 [JPERF-1050]: https://ecosystem.atlassian.net/browse/JPERF-1050
-
-### Fixed
-- Randomly pick between list view and detail view in `JiraCoreScenario`.
+[JPERF-1043]: https://ecosystem.atlassian.net/browse/JPERF-1043
 
 ## [3.18.1] - 2023-02-02
 [3.18.1]: https://github.com/atlassian/jira-actions/compare/release-3.18.0...release-3.18.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 
 [JPERF-1050]: https://ecosystem.atlassian.net/browse/JPERF-1050
 
+### Fixed
+- Randomly pick between list view and detail view in `JiraCoreScenario`.
+
 ## [3.18.1] - 2023-02-02
 [3.18.1]: https://github.com/atlassian/jira-actions/compare/release-3.18.0...release-3.18.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Fixed
 - Disable instance health notifications in `SetUpAction`. Fix [JPERF-1050].
 - Randomly pick between `ListView` and `DetailView` in `JiraCoreScenario`.
+- Measure `IssueNavResultsView` switching.
 
 [JPERF-1050]: https://ecosystem.atlassian.net/browse/JPERF-1050
 [JPERF-1043]: https://ecosystem.atlassian.net/browse/JPERF-1043

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.18.1...master
 
+### Added
+- Add optional `IssueNavigatorView` parameter to JQL actions constructors. Make `IssueNavigationPage` support both list view and split view. Fix [JPERF-1043].
+
 ### Fixed
 - Disable instance health notifications in `SetUpAction`. Fix [JPERF-1050].
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchIssues.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchIssues.kt
@@ -1,0 +1,73 @@
+package com.atlassian.performance.tools.jiraactions.api.action
+
+import com.atlassian.performance.tools.jiraactions.api.ActionType
+import com.atlassian.performance.tools.jiraactions.api.SEARCH_WITH_JQL
+import com.atlassian.performance.tools.jiraactions.api.SeededRandom
+import com.atlassian.performance.tools.jiraactions.api.WebJira
+import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
+import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveIssueKeyMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory
+import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
+import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.IssueNavResultsView
+import org.apache.logging.log4j.LogManager
+import org.apache.logging.log4j.Logger
+import javax.json.JsonObject
+
+class SearchIssues private constructor(
+    private val jira: WebJira,
+    private val meter: ActionMeter,
+    private val actionType: ActionType<SearchJqlObservation>,
+    private val jqlMemory: JqlMemory,
+    private val issueKeyMemory: IssueKeyMemory,
+    private val desiredView: IssueNavResultsView
+) : Action {
+
+    private val logger: Logger = LogManager.getLogger(this::class.java)
+
+    override fun run() {
+        val jqlQuery = jqlMemory.recall()
+        if (jqlQuery == null) {
+            logger.debug("Skipping ${actionType.label} action, because I cannot recall any JQL queries.")
+            return
+        }
+        meter.measure(
+            key = actionType,
+            action = { search(jqlQuery) },
+            observation = this::observe
+        )
+    }
+
+    private fun search(jqlQuery: String) = jira
+        .goToIssueNavigator(jqlQuery)
+        .also { desiredView.switchToView() }
+        .waitForResults(desiredView)
+
+    private fun observe(page: IssueNavigatorPage): JsonObject {
+        val issueKeys = desiredView.listIssueKeys()
+        issueKeyMemory.remember(issueKeys)
+        return SearchJqlObservation(page.jql, issueKeys.size, desiredView.countResults() ?: -1).serialize()
+    }
+
+    class Builder(
+        private var jira: WebJira,
+        private var meter: ActionMeter,
+        seededRandom: SeededRandom
+    ) {
+
+        private var actionType: ActionType<SearchJqlObservation> = SEARCH_WITH_JQL
+        private var jqlMemory: JqlMemory = AdaptiveJqlMemory(seededRandom)
+        private var issueKeyMemory: IssueKeyMemory = AdaptiveIssueKeyMemory(seededRandom)
+        private var desiredView: IssueNavResultsView = DetailView(jira.driver)
+
+        fun actionType(actionType: ActionType<SearchJqlObservation>) = apply { this.actionType = actionType }
+        fun jqlMemory(jqlMemory: JqlMemory) = apply { this.jqlMemory = jqlMemory }
+        fun issueKeyMemory(issueKeyMemory: IssueKeyMemory) = apply { this.issueKeyMemory = issueKeyMemory }
+        fun desiredView(desiredView: IssueNavResultsView) = apply { this.desiredView = desiredView }
+
+        fun build(): Action = SearchIssues(jira, meter, actionType, jqlMemory, issueKeyMemory, desiredView)
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
@@ -7,6 +7,8 @@ import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.IssueNavResultsView
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import javax.json.JsonObject
@@ -16,7 +18,7 @@ class SearchJqlAction(
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory,
-    private val view: IssueNavigatorPage.View = IssueNavigatorPage.View.DETAIL_VIEW
+    private val view: IssueNavResultsView = DetailView(jira.driver)
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -29,7 +31,7 @@ class SearchJqlAction(
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_WITH_JQL,
-            action = { jira.goToIssueNavigator(jqlQuery).switchTo(view).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQuery).also { view.switchToView() }.waitForResults(view) },
             observation = this::observe
         )
         issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
@@ -1,13 +1,13 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
-import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_WITH_JQL
-import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
+import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import javax.json.JsonObject
@@ -16,7 +16,8 @@ class SearchJqlAction(
     private val jira: WebJira,
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
-    private val issueKeyMemory: IssueKeyMemory
+    private val issueKeyMemory: IssueKeyMemory,
+    private val view: IssueNavigatorView = IssueNavigatorView.DETAIL_VIEW
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -29,7 +30,7 @@ class SearchJqlAction(
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_WITH_JQL,
-            action = { jira.goToIssueNavigator(jqlQuery).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQuery).switchLayoutTo(view).waitForIssueNavigator() },
             observation = this::observe
         )
         issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
@@ -7,7 +7,6 @@ import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import javax.json.JsonObject
@@ -17,7 +16,7 @@ class SearchJqlAction(
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory,
-    private val view: IssueNavigatorView = IssueNavigatorView.DETAIL_VIEW
+    private val view: IssueNavigatorPage.View = IssueNavigatorPage.View.DETAIL_VIEW
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
@@ -30,7 +30,7 @@ class SearchJqlAction(
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_WITH_JQL,
-            action = { jira.goToIssueNavigator(jqlQuery).switchLayoutTo(view).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQuery).switchTo(view).waitForIssueNavigator() },
             observation = this::observe
         )
         issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
@@ -32,7 +32,7 @@ class SearchJqlChangelogAction(
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_JQL_CHANGELOG,
-            action = { jira.goToIssueNavigator(jqlQuery).switchLayoutTo(view).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQuery).switchTo(view).waitForIssueNavigator() },
             observation = this::observe
         )
         issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
@@ -7,7 +7,6 @@ import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -19,7 +18,7 @@ class SearchJqlChangelogAction(
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory,
-    private val view: IssueNavigatorView = IssueNavigatorView.DETAIL_VIEW
+    private val view: IssueNavigatorPage.View = IssueNavigatorPage.View.DETAIL_VIEW
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
@@ -1,13 +1,14 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
+import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
-import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.util.function.Predicate
@@ -17,7 +18,8 @@ class SearchJqlChangelogAction(
     private val jira: WebJira,
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
-    private val issueKeyMemory: IssueKeyMemory
+    private val issueKeyMemory: IssueKeyMemory,
+    private val view: IssueNavigatorView = IssueNavigatorView.DETAIL_VIEW
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -30,7 +32,7 @@ class SearchJqlChangelogAction(
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_JQL_CHANGELOG,
-            action = { jira.goToIssueNavigator(jqlQuery).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQuery).switchLayoutTo(view).waitForIssueNavigator() },
             observation = this::observe
         )
         issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
@@ -1,49 +1,28 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
+import com.atlassian.performance.tools.jiraactions.api.SeededRandom
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
-import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
-import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
-import com.atlassian.performance.tools.jiraactions.api.page.issuenav.IssueNavResultsView
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
+import com.atlassian.performance.tools.jiraactions.memories.jql.TagSelectiveJqlMemory
 import java.util.function.Predicate
-import javax.json.JsonObject
 
+@Deprecated("Use SearchIssues.Builder")
 class SearchJqlChangelogAction(
-    private val jira: WebJira,
-    private val meter: ActionMeter,
-    private val jqlMemory: JqlMemory,
-    private val issueKeyMemory: IssueKeyMemory,
-    private val view: IssueNavResultsView = DetailView(jira.driver)
+    jira: WebJira,
+    meter: ActionMeter,
+    jqlMemory: JqlMemory,
+    issueKeyMemory: IssueKeyMemory
 ) : Action {
-    private val logger: Logger = LogManager.getLogger(this::class.java)
 
-    override fun run() {
-        val jqlQuery = jqlMemory.recallByTag(Predicate { it == BuiltInJQL.REPORTERS.name })
-        if (jqlQuery == null) {
-            logger.debug("Skipping ${SEARCH_JQL_CHANGELOG.label} action. I have no knowledge of changelog-specific JQL queries.")
-            return
-        }
+    private val action = SearchIssues.Builder(jira, meter, SeededRandom())
+        .actionType(SEARCH_JQL_CHANGELOG)
+        .jqlMemory(TagSelectiveJqlMemory(jqlMemory, Predicate { it == BuiltInJQL.REPORTERS.name }))
+        .issueKeyMemory(issueKeyMemory)
+        .build()
 
-        val issueNavigatorPage = meter.measure(
-            key = SEARCH_JQL_CHANGELOG,
-            action = { jira.goToIssueNavigator(jqlQuery).also { view.switchToView() }.waitForResults(view) },
-            observation = this::observe
-        )
-        issueKeyMemory.remember(view.listIssueKeys())
-    }
-
-    private fun observe(
-        page: IssueNavigatorPage
-    ): JsonObject {
-        val issueKeys = view.listIssueKeys()
-        issueKeyMemory.remember(issueKeys)
-        return SearchJqlObservation(page.jql, issueKeys.size, view.countResults() ?: 0).serialize()
-    }
+    override fun run() = action.run()
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
@@ -1,6 +1,5 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
-import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_SIMPLE
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
@@ -8,6 +7,7 @@ import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -18,7 +18,8 @@ class SearchJqlSimpleAction(
     private val jira: WebJira,
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
-    private val issueKeyMemory: IssueKeyMemory
+    private val issueKeyMemory: IssueKeyMemory,
+    private val view: IssueNavigatorView = IssueNavigatorView.DETAIL_VIEW
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -31,7 +32,7 @@ class SearchJqlSimpleAction(
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_JQL_SIMPLE,
-            action = { jira.goToIssueNavigator(jqlQueries).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQueries).switchLayoutTo(view).waitForIssueNavigator() },
             observation = this::observe
         )
         issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
@@ -32,7 +32,7 @@ class SearchJqlSimpleAction(
 
         val issueNavigatorPage = meter.measure(
             key = SEARCH_JQL_SIMPLE,
-            action = { jira.goToIssueNavigator(jqlQueries).switchLayoutTo(view).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQueries).switchTo(view).waitForIssueNavigator() },
             observation = this::observe
         )
         issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
@@ -1,49 +1,32 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_SIMPLE
+import com.atlassian.performance.tools.jiraactions.api.SeededRandom
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
-import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
-import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
-import com.atlassian.performance.tools.jiraactions.api.page.issuenav.IssueNavResultsView
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
+import com.atlassian.performance.tools.jiraactions.memories.jql.TagSelectiveJqlMemory
 import java.util.function.Predicate
-import javax.json.JsonObject
 
+@Deprecated("Use SearchIssues.Builder")
 class SearchJqlSimpleAction(
-    private val jira: WebJira,
-    private val meter: ActionMeter,
-    private val jqlMemory: JqlMemory,
-    private val issueKeyMemory: IssueKeyMemory,
-    private val view: IssueNavResultsView = DetailView(jira.driver)
+    jira: WebJira,
+    meter: ActionMeter,
+    jqlMemory: JqlMemory,
+    issueKeyMemory: IssueKeyMemory
 ) : Action {
-    private val logger: Logger = LogManager.getLogger(this::class.java)
 
-    override fun run() {
-        val jqlQueries = jqlMemory.recallByTag(Predicate { it != BuiltInJQL.GENERIC_WIDE.name && it != BuiltInJQL.REPORTERS.name })
-        if (jqlQueries == null) {
-            logger.debug("Skipping ${SEARCH_JQL_SIMPLE.label} action. I have no knowledge of simple JQL queries.")
-            return
-        }
-
-        meter.measure(
-            key = SEARCH_JQL_SIMPLE,
-            action = { jira.goToIssueNavigator(jqlQueries).also { view.switchToView() }.waitForResults(view) },
-            observation = this::observe
-        )
-        issueKeyMemory.remember(view.listIssueKeys())
+    private val jqlTagFilter: Predicate<String> = Predicate {
+        it != BuiltInJQL.GENERIC_WIDE.name && it != BuiltInJQL.REPORTERS.name
     }
 
-    private fun observe(
-        page: IssueNavigatorPage
-    ): JsonObject {
-        val issueKeys = view.listIssueKeys()
-        issueKeyMemory.remember(issueKeys)
-        return SearchJqlObservation(page.jql, issueKeys.size, view.countResults() ?: 0).serialize()
-    }
+    private val action = SearchIssues.Builder(jira, meter, SeededRandom())
+        .actionType(SEARCH_JQL_SIMPLE)
+        .jqlMemory(TagSelectiveJqlMemory(jqlMemory, jqlTagFilter))
+        .issueKeyMemory(issueKeyMemory)
+        .build()
+
+    override fun run() = action.run()
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
@@ -7,6 +7,8 @@ import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.IssueNavResultsView
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -18,7 +20,7 @@ class SearchJqlSimpleAction(
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory,
-    private val view: IssueNavigatorPage.View = IssueNavigatorPage.View.DETAIL_VIEW
+    private val view: IssueNavResultsView = DetailView(jira.driver)
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 
@@ -29,19 +31,19 @@ class SearchJqlSimpleAction(
             return
         }
 
-        val issueNavigatorPage = meter.measure(
+        meter.measure(
             key = SEARCH_JQL_SIMPLE,
-            action = { jira.goToIssueNavigator(jqlQueries).switchTo(view).waitForIssueNavigator() },
+            action = { jira.goToIssueNavigator(jqlQueries).also { view.switchToView() }.waitForResults(view) },
             observation = this::observe
         )
-        issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())
+        issueKeyMemory.remember(view.listIssueKeys())
     }
 
     private fun observe(
         page: IssueNavigatorPage
     ): JsonObject {
-        val issueKeys = page.getIssueKeys()
+        val issueKeys = view.listIssueKeys()
         issueKeyMemory.remember(issueKeys)
-        return SearchJqlObservation(page.jql, issueKeys.size, page.getTotalResults()).serialize()
+        return SearchJqlObservation(page.jql, issueKeys.size, view.countResults() ?: 0).serialize()
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
@@ -7,7 +7,6 @@ import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
 import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
@@ -19,7 +18,7 @@ class SearchJqlSimpleAction(
     private val meter: ActionMeter,
     private val jqlMemory: JqlMemory,
     private val issueKeyMemory: IssueKeyMemory,
-    private val view: IssueNavigatorView = IssueNavigatorView.DETAIL_VIEW
+    private val view: IssueNavigatorPage.View = IssueNavigatorPage.View.DETAIL_VIEW
 ) : Action {
     private val logger: Logger = LogManager.getLogger(this::class.java)
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlWildcardAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlWildcardAction.kt
@@ -1,47 +1,28 @@
 package com.atlassian.performance.tools.jiraactions.api.action
 
-import com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG
 import com.atlassian.performance.tools.jiraactions.api.SEARCH_WITH_JQL_WILDCARD
+import com.atlassian.performance.tools.jiraactions.api.SeededRandom
 import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
-import com.atlassian.performance.tools.jiraactions.api.observation.SearchJqlObservation
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
-import org.apache.logging.log4j.LogManager
-import org.apache.logging.log4j.Logger
+import com.atlassian.performance.tools.jiraactions.memories.jql.TagSelectiveJqlMemory
 import java.util.function.Predicate
-import javax.json.JsonObject
 
+@Deprecated("Use SearchIssues.Builder")
 class SearchJqlWildcardAction(
-    private val jira: WebJira,
-    private val meter: ActionMeter,
-    private val jqlMemory: JqlMemory,
-    private val issueKeyMemory: IssueKeyMemory
+    jira: WebJira,
+    meter: ActionMeter,
+    jqlMemory: JqlMemory,
+    issueKeyMemory: IssueKeyMemory
 ) : Action {
-    private val logger: Logger = LogManager.getLogger(this::class.java)
 
-    override fun run() {
-        val jqlQuery = jqlMemory.recallByTag(Predicate { it == BuiltInJQL.GENERIC_WIDE.name })
-        if (jqlQuery == null) {
-            logger.debug("Skipping ${SEARCH_WITH_JQL_WILDCARD.label} action. I have no knowledge of wildcard JQL queries.")
-            return
-        }
+    private val action = SearchIssues.Builder(jira, meter, SeededRandom())
+        .actionType(SEARCH_WITH_JQL_WILDCARD)
+        .jqlMemory(TagSelectiveJqlMemory(jqlMemory, Predicate { it == BuiltInJQL.GENERIC_WIDE.name }))
+        .issueKeyMemory(issueKeyMemory)
+        .build()
 
-        val issueNavigatorPage = meter.measure(
-            key = SEARCH_WITH_JQL_WILDCARD,
-            action = { jira.goToIssueNavigator(jqlQuery).waitForIssueNavigator() },
-            observation = this::observe
-        )
-        issueKeyMemory.remember(issueNavigatorPage.getIssueKeys())
-    }
-
-    private fun observe(
-        page: IssueNavigatorPage
-    ): JsonObject {
-        val issueKeys = page.getIssueKeys()
-        issueKeyMemory.remember(issueKeys)
-        return SearchJqlObservation(page.jql, issueKeys.size, page.getTotalResults()).serialize()
-    }
+    override fun run() = action.run()
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
@@ -6,40 +6,63 @@ import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.p
 import com.atlassian.performance.tools.jiraactions.api.webdriver.JavaScriptUtils
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
 import java.time.Duration
 
 open class IssueNavigatorPage(
     private val driver: WebDriver,
     val jql: String
 ) {
+    private val detailView = and(
+        or(
+            presenceOfElementLocated(By.cssSelector("ol.issue-list")),
+            presenceOfElementLocated(By.id("issuetable")),
+            presenceOfElementLocated(By.id("issue-content"))
+        ),
+        presenceOfElementLocated(By.id("key-val")),
+        presenceOfElementLocated(By.className("issue-body-content"))
+    )
+    private val listView = and(
+        presenceOfElementLocated(By.id("issuetable")),
+        presenceOfElementLocated(By.cssSelector(".issuerow.focused"))
+    )
+    private val emptyResults = presenceOfElementLocated(By.className("no-results-hint"))
 
-    /**
-     * Requires an issue detail pane to be visible.
-     * For example, if there are no issues found, this will time out.
-     */
     fun waitForIssueNavigator(): IssueNavigatorPage {
         val jiraErrors = JiraErrors(driver)
         driver.wait(
-            Duration.ofSeconds(30),
+            Duration.ofSeconds(10),
             or(
-                and(
-                    or(
-                        presenceOfElementLocated(By.cssSelector("ol.issue-list")),
-                        presenceOfElementLocated(By.id("issuetable")),
-                        presenceOfElementLocated(By.id("issue-content"))
-                    ),
-                    presenceOfElementLocated(By.id("key-val")),
-                    presenceOfElementLocated(By.className("issue-body-content"))
-                ),
-                presenceOfElementLocated(By.className("no-results-hint")),
+                detailView,
+                listView,
+                emptyResults,
                 jiraErrors.anyCommonErrorNative()
             )
         )
         return this
     }
 
+    fun switchLayoutTo(view: IssueNavigatorView): IssueNavigatorPage {
+        val currentLayout = getCurrentLayout()
+        if (currentLayout != view) {
+            driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
+            driver.wait(elementToBeClickable(By.cssSelector("a[data-layout-key=${view.selector}]"))).click()
+        }
+        return this
+    }
+
+    private fun getCurrentLayout(): IssueNavigatorView {
+        driver.wait(Duration.ofSeconds(10), presenceOfElementLocated(By.className("results-panel")))
+        return if (driver.isElementPresent(By.cssSelector("div.list-view"))) {
+            IssueNavigatorView.LIST_VIEW
+        } else {
+            IssueNavigatorView.DETAIL_VIEW
+        }
+    }
+
     open fun getIssueKeys(): Set<String> {
-        val issueKeys: List<String> = JavaScriptUtils.executeScript(driver,
+        val issueKeys: List<String> = JavaScriptUtils.executeScript(
+            driver,
             "return Array.from(document.getElementsByClassName('issue-link-key'), i => i.innerText.trim())"
         )
 
@@ -54,7 +77,7 @@ open class IssueNavigatorPage(
         return IssuePage(driver).getIssueId()
     }
 
-    protected fun getDriver() : WebDriver {
+    protected fun getDriver(): WebDriver {
         return this.driver
     }
 
@@ -65,4 +88,9 @@ open class IssueNavigatorPage(
         ?.trim()
         ?.substringAfter("of ")
         ?.toInt() ?: 0
+}
+
+enum class IssueNavigatorView(val selector: String) {
+    LIST_VIEW("list-view"),
+    DETAIL_VIEW("split-view")
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
@@ -4,7 +4,7 @@ import com.atlassian.performance.seleniumjs.NativeExpectedCondition
 import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.and
 import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.or
 import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.presenceOfElementLocated
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView.*
+import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage.View.*
 import com.atlassian.performance.tools.jiraactions.api.webdriver.JavaScriptUtils
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
@@ -31,7 +31,7 @@ open class IssueNavigatorPage(
         return this
     }
 
-    fun switchTo(view: IssueNavigatorView): IssueNavigatorPage {
+    fun switchTo(view: View): IssueNavigatorPage {
         val currentView = getCurrentView()
         if (currentView != view) {
             driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
@@ -40,7 +40,7 @@ open class IssueNavigatorPage(
         return this
     }
 
-    private fun getCurrentView(): IssueNavigatorView {
+    private fun getCurrentView(): View {
         driver.wait(Duration.ofSeconds(10), presenceOfElementLocated(By.className("results-panel")))
         return if (driver.isElementPresent(By.cssSelector("div.list-view"))) {
             LIST_VIEW
@@ -77,29 +77,29 @@ open class IssueNavigatorPage(
         ?.trim()
         ?.substringAfter("of ")
         ?.toInt() ?: 0
-}
 
-enum class IssueNavigatorView(
-    val selector: String,
-    val resultsPresent: NativeExpectedCondition
-) {
-    LIST_VIEW(
-        "list-view",
-        and(
-            presenceOfElementLocated(By.id("issuetable")),
-            presenceOfElementLocated(By.cssSelector(".issuerow.focused"))
-        )
-    ),
-    DETAIL_VIEW(
-        "split-view",
-        and(
-            or(
-                presenceOfElementLocated(By.cssSelector("ol.issue-list")),
+    enum class View(
+        val selector: String,
+        val resultsPresent: NativeExpectedCondition
+    ) {
+        LIST_VIEW(
+            "list-view",
+            and(
                 presenceOfElementLocated(By.id("issuetable")),
-                presenceOfElementLocated(By.id("issue-content"))
-            ),
-            presenceOfElementLocated(By.id("key-val")),
-            presenceOfElementLocated(By.className("issue-body-content"))
+                presenceOfElementLocated(By.cssSelector(".issuerow.focused"))
+            )
+        ),
+        DETAIL_VIEW(
+            "split-view",
+            and(
+                or(
+                    presenceOfElementLocated(By.cssSelector("ol.issue-list")),
+                    presenceOfElementLocated(By.id("issuetable")),
+                    presenceOfElementLocated(By.id("issue-content"))
+                ),
+                presenceOfElementLocated(By.id("key-val")),
+                presenceOfElementLocated(By.className("issue-body-content"))
+            )
         )
-    )
+    }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueNavigatorPage.kt
@@ -1,14 +1,12 @@
 package com.atlassian.performance.tools.jiraactions.api.page
 
-import com.atlassian.performance.seleniumjs.NativeExpectedCondition
-import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.and
 import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.or
 import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.presenceOfElementLocated
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage.View.*
-import com.atlassian.performance.tools.jiraactions.api.webdriver.JavaScriptUtils
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.IssueNavResultsView
+import com.atlassian.performance.tools.jiraactions.page.issuenav.UnknownView
 import org.openqa.selenium.By
 import org.openqa.selenium.WebDriver
-import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
 import java.time.Duration
 
 open class IssueNavigatorPage(
@@ -17,13 +15,15 @@ open class IssueNavigatorPage(
 ) {
     private val emptyResults = presenceOfElementLocated(By.className("no-results-hint"))
 
-    fun waitForIssueNavigator(): IssueNavigatorPage {
+    @Deprecated("Waiting for results depend on the results view", ReplaceWith("waitForResults"))
+    fun waitForIssueNavigator(): IssueNavigatorPage = waitForResults(UnknownView(driver))
+
+    fun waitForResults(results: IssueNavResultsView): IssueNavigatorPage {
         val jiraErrors = JiraErrors(driver)
         driver.wait(
             Duration.ofSeconds(10),
             or(
-                DETAIL_VIEW.resultsPresent,
-                LIST_VIEW.resultsPresent,
+                results.detectResults(),
                 emptyResults,
                 jiraErrors.anyCommonErrorNative()
             )
@@ -31,32 +31,9 @@ open class IssueNavigatorPage(
         return this
     }
 
-    fun switchTo(view: View): IssueNavigatorPage {
-        val currentView = getCurrentView()
-        if (currentView != view) {
-            driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
-            driver.wait(elementToBeClickable(By.cssSelector("a[data-layout-key=${view.selector}]"))).click()
-        }
-        return this
-    }
 
-    private fun getCurrentView(): View {
-        driver.wait(Duration.ofSeconds(10), presenceOfElementLocated(By.className("results-panel")))
-        return if (driver.isElementPresent(By.cssSelector("div.list-view"))) {
-            LIST_VIEW
-        } else {
-            DETAIL_VIEW
-        }
-    }
-
-    open fun getIssueKeys(): Set<String> {
-        val issueKeys: List<String> = JavaScriptUtils.executeScript(
-            driver,
-            "return Array.from(document.getElementsByClassName('issue-link-key'), i => i.innerText.trim())"
-        )
-
-        return HashSet(issueKeys)
-    }
+    @Deprecated("Issue keys depend on the results view", ReplaceWith("IssueNavResultsView.listIssueKeys().toSet()"))
+    open fun getIssueKeys(): Set<String> = UnknownView(driver).listIssueKeys().toSet()
 
     fun issueView(): IssuePage {
         return IssuePage(driver)
@@ -70,36 +47,6 @@ open class IssueNavigatorPage(
         return this.driver
     }
 
-    fun getTotalResults(): Int = driver
-        .findElements(By.className("showing"))
-        .singleOrNull()
-        ?.text
-        ?.trim()
-        ?.substringAfter("of ")
-        ?.toInt() ?: 0
-
-    enum class View(
-        val selector: String,
-        val resultsPresent: NativeExpectedCondition
-    ) {
-        LIST_VIEW(
-            "list-view",
-            and(
-                presenceOfElementLocated(By.id("issuetable")),
-                presenceOfElementLocated(By.cssSelector(".issuerow.focused"))
-            )
-        ),
-        DETAIL_VIEW(
-            "split-view",
-            and(
-                or(
-                    presenceOfElementLocated(By.cssSelector("ol.issue-list")),
-                    presenceOfElementLocated(By.id("issuetable")),
-                    presenceOfElementLocated(By.id("issue-content"))
-                ),
-                presenceOfElementLocated(By.id("key-val")),
-                presenceOfElementLocated(By.className("issue-body-content"))
-            )
-        )
-    }
+    @Deprecated("Total results depend on the results view", ReplaceWith("IssueNavResultsView.countResults()"))
+    fun getTotalResults(): Int = UnknownView(driver).countResults() ?: 0
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/DetailView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/DetailView.kt
@@ -1,0 +1,53 @@
+package com.atlassian.performance.tools.jiraactions.api.page.issuenav
+
+import com.atlassian.performance.seleniumjs.NativeExpectedCondition
+import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.and
+import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.or
+import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.presenceOfElementLocated
+import com.atlassian.performance.tools.jiraactions.api.page.isElementPresent
+import com.atlassian.performance.tools.jiraactions.api.page.wait
+import com.atlassian.performance.tools.jiraactions.api.webdriver.JavaScriptUtils
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
+import java.time.Duration
+
+class DetailView(
+    private val driver: WebDriver
+) : IssueNavResultsView {
+
+    private fun isSelected(): Boolean {
+        driver.wait(Duration.ofSeconds(10), presenceOfElementLocated(By.className("results-panel")))
+        return driver.isElementPresent(By.className("details-layout"))
+    }
+
+    override fun switchToView() {
+        if (!isSelected()) {
+            driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
+            driver.wait(elementToBeClickable(By.cssSelector("[data-layout-key=split-view]"))).click()
+        }
+    }
+
+    override fun detectResults(): NativeExpectedCondition = and(
+        or(
+            presenceOfElementLocated(By.className("issue-list")),
+            presenceOfElementLocated(By.id("issuetable")),
+            presenceOfElementLocated(By.id("issue-content"))
+        ),
+        presenceOfElementLocated(By.id("key-val")),
+        presenceOfElementLocated(By.className("issue-body-content"))
+    )
+
+    override fun countResults(): Int? = driver
+        .findElements(By.className("showing"))
+        .singleOrNull()
+        ?.text
+        ?.trim()
+        ?.substringAfter("of ")
+        ?.toInt()
+
+    override fun listIssueKeys(): List<String> = JavaScriptUtils.executeScript(
+        driver,
+        "return Array.from(document.getElementsByClassName('issue-link-key'), i => i.innerText.trim())"
+    )
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/DetailView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/DetailView.kt
@@ -16,16 +16,14 @@ class DetailView(
     private val driver: WebDriver
 ) : IssueNavResultsView {
 
-    private fun isSelected(): Boolean {
+    override fun isSelected(): Boolean {
         driver.wait(Duration.ofSeconds(10), presenceOfElementLocated(By.className("results-panel")))
         return driver.isElementPresent(By.className("details-layout"))
     }
 
     override fun switchToView() {
-        if (!isSelected()) {
-            driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
-            driver.wait(elementToBeClickable(By.cssSelector("[data-layout-key=split-view]"))).click()
-        }
+        driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
+        driver.wait(elementToBeClickable(By.cssSelector("[data-layout-key=split-view]"))).click()
     }
 
     override fun detectResults(): NativeExpectedCondition = and(

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/IssueNavResultsView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/IssueNavResultsView.kt
@@ -5,6 +5,11 @@ import com.atlassian.performance.seleniumjs.NativeExpectedCondition
 interface IssueNavResultsView {
 
     /**
+     * @return true if the view is already selected, false otherwise
+     */
+    fun isSelected(): Boolean
+
+    /**
      * Switch to the issue nav results view (like detail or list).
      */
     fun switchToView()

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/IssueNavResultsView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/IssueNavResultsView.kt
@@ -1,0 +1,26 @@
+package com.atlassian.performance.tools.jiraactions.api.page.issuenav
+
+import com.atlassian.performance.seleniumjs.NativeExpectedCondition
+
+interface IssueNavResultsView {
+
+    /**
+     * Switch to the issue nav results view (like detail or list).
+     */
+    fun switchToView()
+
+    /**
+     * @return condition, which is satisfied if the results view shows results
+     */
+    fun detectResults(): NativeExpectedCondition
+
+    /**
+     * @return total issues found or null if unknown (e.g. search failed)
+     */
+    fun countResults(): Int?
+
+    /**
+     * @return a sample of found issue keys
+     */
+    fun listIssueKeys(): List<String>
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/ListView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/ListView.kt
@@ -1,0 +1,44 @@
+package com.atlassian.performance.tools.jiraactions.api.page.issuenav
+
+import com.atlassian.performance.seleniumjs.NativeExpectedCondition
+import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.and
+import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.presenceOfElementLocated
+import com.atlassian.performance.tools.jiraactions.api.page.isElementPresent
+import com.atlassian.performance.tools.jiraactions.api.page.wait
+import org.openqa.selenium.By
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.support.ui.ExpectedConditions.elementToBeClickable
+import java.time.Duration
+
+class ListView(
+    private val driver: WebDriver
+) : IssueNavResultsView {
+
+    private fun isSelected(): Boolean {
+        driver.wait(Duration.ofSeconds(10), presenceOfElementLocated(By.className("results-panel")))
+        return driver.isElementPresent(By.className("list-view"))
+    }
+
+    override fun switchToView() {
+        if (!isSelected()) {
+            driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
+            driver.wait(elementToBeClickable(By.cssSelector("[data-layout-key=list-view]"))).click()
+        }
+    }
+
+    override fun detectResults(): NativeExpectedCondition = and(
+        presenceOfElementLocated(By.id("issuetable")),
+        presenceOfElementLocated(By.className("issuerow"))
+    )
+
+    override fun countResults(): Int? = driver
+        .findElements(By.className("results-count-total"))
+        .singleOrNull()
+        ?.text
+        ?.trim()
+        ?.toInt()
+
+    override fun listIssueKeys(): List<String> = driver
+        .findElements(By.cssSelector("[data-issuekey]"))
+        .map { it.getAttribute("[data-issuekey") }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/ListView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/issuenav/ListView.kt
@@ -14,16 +14,14 @@ class ListView(
     private val driver: WebDriver
 ) : IssueNavResultsView {
 
-    private fun isSelected(): Boolean {
+    override fun isSelected(): Boolean {
         driver.wait(Duration.ofSeconds(10), presenceOfElementLocated(By.className("results-panel")))
         return driver.isElementPresent(By.className("list-view"))
     }
 
     override fun switchToView() {
-        if (!isSelected()) {
-            driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
-            driver.wait(elementToBeClickable(By.cssSelector("[data-layout-key=list-view]"))).click()
-        }
+        driver.wait(elementToBeClickable(By.id("layout-switcher-button"))).click()
+        driver.wait(elementToBeClickable(By.cssSelector("[data-layout-key=list-view]"))).click()
     }
 
     override fun detectResults(): NativeExpectedCondition = and(

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
@@ -6,6 +6,7 @@ import com.atlassian.performance.tools.jiraactions.api.action.*
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.*
+import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
 
 /**
  * Provides Jira Core specific `Scenario`.
@@ -45,7 +46,8 @@ class JiraCoreScenario constructor() : Scenario {
             jira = jira,
             meter = meter,
             jqlMemory = jqlMemory,
-            issueKeyMemory = issueKeyMemory
+            issueKeyMemory = issueKeyMemory,
+            view = seededRandom.pick(IssueNavigatorView.values().toList())!!
         )
         val viewIssue = ViewIssueAction.Builder(jira, meter)
             .issueKeyMemory(issueKeyMemory)

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
@@ -43,13 +43,11 @@ class JiraCoreScenario constructor() : Scenario {
             seededRandom = seededRandom,
             projectMemory = projectMemory
         )
-        val searchWithJql = SearchJqlAction(
-            jira = jira,
-            meter = meter,
-            jqlMemory = jqlMemory,
-            issueKeyMemory = issueKeyMemory,
-            view = seededRandom.pick(listOf(DetailView(jira.driver), ListView(jira.driver)))!!
-        )
+        val searchWithJql = SearchIssues.Builder(jira, meter, seededRandom)
+            .jqlMemory(jqlMemory)
+            .issueKeyMemory(issueKeyMemory)
+            .desiredView(seededRandom.pick(listOf(DetailView(jira.driver), ListView(jira.driver)))!!)
+            .build()
         val viewIssue = ViewIssueAction.Builder(jira, meter)
             .issueKeyMemory(issueKeyMemory)
             .issueMemory(issueMemory)

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
@@ -6,7 +6,7 @@ import com.atlassian.performance.tools.jiraactions.api.action.*
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.*
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorView
+import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
 
 /**
  * Provides Jira Core specific `Scenario`.
@@ -47,7 +47,7 @@ class JiraCoreScenario constructor() : Scenario {
             meter = meter,
             jqlMemory = jqlMemory,
             issueKeyMemory = issueKeyMemory,
-            view = seededRandom.pick(IssueNavigatorView.values().toList())!!
+            view = seededRandom.pick(IssueNavigatorPage.View.values().toList())!!
         )
         val viewIssue = ViewIssueAction.Builder(jira, meter)
             .issueKeyMemory(issueKeyMemory)

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/scenario/JiraCoreScenario.kt
@@ -6,7 +6,8 @@ import com.atlassian.performance.tools.jiraactions.api.action.*
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.*
-import com.atlassian.performance.tools.jiraactions.api.page.IssueNavigatorPage
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.ListView
 
 /**
  * Provides Jira Core specific `Scenario`.
@@ -47,7 +48,7 @@ class JiraCoreScenario constructor() : Scenario {
             meter = meter,
             jqlMemory = jqlMemory,
             issueKeyMemory = issueKeyMemory,
-            view = seededRandom.pick(IssueNavigatorPage.View.values().toList())!!
+            view = seededRandom.pick(listOf(DetailView(jira.driver), ListView(jira.driver)))!!
         )
         val viewIssue = ViewIssueAction.Builder(jira, meter)
             .issueKeyMemory(issueKeyMemory)

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/memories/jql/TagSelectiveJqlMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/memories/jql/TagSelectiveJqlMemory.kt
@@ -1,0 +1,15 @@
+package com.atlassian.performance.tools.jiraactions.memories.jql
+
+import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
+import java.util.function.Predicate
+
+/**
+ * Only [recall]s so called "tagged" JQLs matching the filter.
+ */
+internal class TagSelectiveJqlMemory(
+    private val memory: JqlMemory,
+    private val jqlTagFilter: Predicate<String>
+) : JqlMemory by memory {
+
+    override fun recall() = memory.recallByTag(jqlTagFilter)
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/issuenav/UnknownView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/issuenav/UnknownView.kt
@@ -1,0 +1,29 @@
+package com.atlassian.performance.tools.jiraactions.page.issuenav
+
+import com.atlassian.performance.seleniumjs.NativeExpectedCondition
+import com.atlassian.performance.seleniumjs.NativeExpectedConditions.Companion.or
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.DetailView
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.IssueNavResultsView
+import com.atlassian.performance.tools.jiraactions.api.page.issuenav.ListView
+import org.openqa.selenium.WebDriver
+
+class UnknownView(
+    driver: WebDriver
+) : IssueNavResultsView {
+
+    private val detail = DetailView(driver)
+    private val list = ListView(driver)
+
+    override fun switchToView() {
+        // unknown
+    }
+
+    override fun detectResults(): NativeExpectedCondition = or(
+        detail.detectResults(),
+        list.detectResults()
+    )
+
+    override fun countResults(): Int? = detail.countResults() ?: list.countResults()
+
+    override fun listIssueKeys(): List<String> = detail.listIssueKeys() + list.listIssueKeys()
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/issuenav/UnknownView.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/issuenav/UnknownView.kt
@@ -14,6 +14,8 @@ class UnknownView(
     private val detail = DetailView(driver)
     private val list = ListView(driver)
 
+    override fun isSelected(): Boolean = detail.isSelected() || list.isSelected()
+
     override fun switchToView() {
         // unknown
     }


### PR DESCRIPTION
Add support for list view on IssueNavigatorPage:
- Add IssueNavigatorView enum class that represents both available layouts and use it as an optional parameter in SearchJqlSimpleAction and SearchJqlSimpleAction constructors. When no value is provided, the detail view will be used as a default layout.
- While visiting the IssueNavigatorPage current view is detected and changed to the desired view if needed.
