### PR TITLE
JPERF-1043: Offer JQL filtering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.19.0...master
 
+### Added
+- Add `AdaptiveJqlMemory.Companion` JQL filtering extension functions.
+  With them, you can actually replace the deprecated `SearchJql*Action`s.
+
 ## [3.19.0] - 2023-03-30
 [3.19.0]: https://github.com/atlassian/jira-actions/compare/release-3.18.1...release-3.19.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlAction.kt
@@ -7,7 +7,14 @@ import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
 
-@Deprecated("Use SearchIssues.Builder")
+@Deprecated(
+    "Use SearchIssues.Builder",
+    ReplaceWith(
+        "SearchIssues.Builder(jira, meter, SeededRandom()).actionType(SEARCH_WITH_JQL).jqlMemory(jqlMemory).issueKeyMemory(issueKeyMemory).build()",
+        "com.atlassian.performance.tools.jiraactions.api.SEARCH_WITH_JQL",
+        "com.atlassian.performance.tools.jiraactions.api.SeededRandom"
+    )
+)
 class SearchJqlAction(
     jira: WebJira,
     meter: ActionMeter,

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlChangelogAction.kt
@@ -6,11 +6,20 @@ import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory.Companion.changelog
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import com.atlassian.performance.tools.jiraactions.memories.jql.TagSelectiveJqlMemory
 import java.util.function.Predicate
 
-@Deprecated("Use SearchIssues.Builder")
+@Deprecated(
+    "Use SearchIssues.Builder",
+    ReplaceWith(
+        "SearchIssues.Builder(jira, meter, SeededRandom()).actionType(SEARCH_JQL_CHANGELOG).jqlMemory(jqlMemory.changelog()).issueKeyMemory(issueKeyMemory).build()",
+        "com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_CHANGELOG",
+        "com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory.Companion.changelog",
+        "com.atlassian.performance.tools.jiraactions.api.SeededRandom"
+    )
+)
 class SearchJqlChangelogAction(
     jira: WebJira,
     meter: ActionMeter,
@@ -20,7 +29,7 @@ class SearchJqlChangelogAction(
 
     private val action = SearchIssues.Builder(jira, meter, SeededRandom())
         .actionType(SEARCH_JQL_CHANGELOG)
-        .jqlMemory(TagSelectiveJqlMemory(jqlMemory, Predicate { it == BuiltInJQL.REPORTERS.name }))
+        .jqlMemory(jqlMemory.changelog())
         .issueKeyMemory(issueKeyMemory)
         .build()
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlSimpleAction.kt
@@ -6,11 +6,17 @@ import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
-import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
-import com.atlassian.performance.tools.jiraactions.memories.jql.TagSelectiveJqlMemory
-import java.util.function.Predicate
+import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory.Companion.simple
 
-@Deprecated("Use SearchIssues.Builder")
+@Deprecated(
+    "Use SearchIssues.Builder",
+    ReplaceWith(
+        "SearchIssues.Builder(jira, meter, SeededRandom()).actionType(SEARCH_JQL_SIMPLE).jqlMemory(jqlMemory.simple()).issueKeyMemory(issueKeyMemory).build()",
+        "com.atlassian.performance.tools.jiraactions.api.SEARCH_JQL_SIMPLE",
+        "com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory.Companion.simple",
+        "com.atlassian.performance.tools.jiraactions.api.SeededRandom"
+    )
+)
 class SearchJqlSimpleAction(
     jira: WebJira,
     meter: ActionMeter,
@@ -18,13 +24,9 @@ class SearchJqlSimpleAction(
     issueKeyMemory: IssueKeyMemory
 ) : Action {
 
-    private val jqlTagFilter: Predicate<String> = Predicate {
-        it != BuiltInJQL.GENERIC_WIDE.name && it != BuiltInJQL.REPORTERS.name
-    }
-
     private val action = SearchIssues.Builder(jira, meter, SeededRandom())
         .actionType(SEARCH_JQL_SIMPLE)
-        .jqlMemory(TagSelectiveJqlMemory(jqlMemory, jqlTagFilter))
+        .jqlMemory(jqlMemory.simple())
         .issueKeyMemory(issueKeyMemory)
         .build()
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlWildcardAction.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/action/SearchJqlWildcardAction.kt
@@ -6,11 +6,20 @@ import com.atlassian.performance.tools.jiraactions.api.WebJira
 import com.atlassian.performance.tools.jiraactions.api.measure.ActionMeter
 import com.atlassian.performance.tools.jiraactions.api.memories.IssueKeyMemory
 import com.atlassian.performance.tools.jiraactions.api.memories.JqlMemory
+import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory.Companion.wildcard
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
 import com.atlassian.performance.tools.jiraactions.memories.jql.TagSelectiveJqlMemory
 import java.util.function.Predicate
 
-@Deprecated("Use SearchIssues.Builder")
+@Deprecated(
+    "Use SearchIssues.Builder",
+    ReplaceWith(
+        "SearchIssues.Builder(jira, meter, SeededRandom()).actionType(SEARCH_WITH_JQL_WILDCARD).jqlMemory(jqlMemory.wildcard()).issueKeyMemory(issueKeyMemory).build()",
+        "com.atlassian.performance.tools.jiraactions.api.SEARCH_WITH_JQL_WILDCARD",
+        "com.atlassian.performance.tools.jiraactions.api.memories.adaptive.AdaptiveJqlMemory.Companion.wildcard",
+        "com.atlassian.performance.tools.jiraactions.api.SeededRandom"
+    )
+)
 class SearchJqlWildcardAction(
     jira: WebJira,
     meter: ActionMeter,
@@ -20,7 +29,7 @@ class SearchJqlWildcardAction(
 
     private val action = SearchIssues.Builder(jira, meter, SeededRandom())
         .actionType(SEARCH_WITH_JQL_WILDCARD)
-        .jqlMemory(TagSelectiveJqlMemory(jqlMemory, Predicate { it == BuiltInJQL.GENERIC_WIDE.name }))
+        .jqlMemory(jqlMemory.wildcard())
         .issueKeyMemory(issueKeyMemory)
         .build()
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/adaptive/AdaptiveJqlMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/memories/adaptive/AdaptiveJqlMemory.kt
@@ -6,6 +6,7 @@ import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.jql.Jql
 import com.atlassian.performance.tools.jiraactions.api.memories.adaptive.jql.JqlPrescriptions
 import com.atlassian.performance.tools.jiraactions.api.page.IssuePage
 import com.atlassian.performance.tools.jiraactions.jql.BuiltInJQL
+import com.atlassian.performance.tools.jiraactions.memories.jql.TagSelectiveJqlMemory
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import java.util.function.Predicate
@@ -18,6 +19,16 @@ class AdaptiveJqlMemory(
 
     companion object {
         fun getAvailableTags(): List<String> = BuiltInJQL.values().map { it.name }.toList()
+
+        fun JqlMemory.simple() = filterJqls { tag ->
+            tag != BuiltInJQL.GENERIC_WIDE.name && tag != BuiltInJQL.REPORTERS.name
+        }
+        fun JqlMemory.changelog() = filterJqls { tag -> tag == BuiltInJQL.REPORTERS.name }
+        fun JqlMemory.wildcard() = filterJqls { tag -> tag == BuiltInJQL.GENERIC_WIDE.name }
+
+        private fun JqlMemory.filterJqls(
+            tagFilter: (String) -> Boolean
+        ): JqlMemory = TagSelectiveJqlMemory(this, Predicate { tagFilter(it) })
     }
 
     private val jqls = mutableListOf(


### PR DESCRIPTION
It's necessary to replace the deprecated `SearchJql*Action`s.

The new extension functions don't spread the smell of `recallByTag` and its `TagSelectiveJqlMemory` bridge.
The `BuiltInJQL` enum remains hidden.

Yes, `AdaptiveJqlMemory.Companion` is not pretty,
but this API already existed.

PS. Improve `@Deprecated` to make replacements easier.