### PR TITLE
JPERF-1052 Change the expected condition in View History Tab action that is used to verify if the content is loaded.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 - Add `AdaptiveJqlMemory.Companion` JQL filtering extension functions.
   With them, you can actually replace the deprecated `SearchJql*Action`s.
 
+### Fixed
+- Change the condition used to verify if the content is loading in `ViewHistoryTabAction` to avoid TimeoutException. Fix [JPERF-1052].
+
+[JPERF-1052]: https://ecosystem.atlassian.net/browse/JPERF-1052
+
 ## [3.19.0] - 2023-03-30
 [3.19.0]: https://github.com/atlassian/jira-actions/compare/release-3.18.1...release-3.19.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
@@ -53,7 +53,7 @@ class HistoryTabPanel(
                 .perform()
             driver.wait(
                 duration,
-                ExpectedConditions.stalenessOf(loadMoreButton)
+                ExpectedConditions.invisibilityOfElementLocated(By.xpath("//button[@aria-busy='true']"))
             )
         }
         return this


### PR DESCRIPTION
Previously used 'stalenessOf' caused many timeout exceptions when clicking on the button was not successful. A new condition is more relaxed and when the button lacks the attribute indicating that the content is loading, the click will be repeated.