### PR TITLE
JPERF-1060: Close flags before using administration menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.20.1...master
 
+### Fixed
+- Close flags before using administration menu. Fix [JPERF-1060].
+
+[JPERF-1060]: https://ecosystem.atlassian.net/browse/JPERF-1060
+
 ## [3.20.1] - 2023-04-03
 [3.20.1]: https://github.com/atlassian/jira-actions/compare/release-3.20.0...3.20.1
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
@@ -107,6 +107,7 @@ data class WebJira(
     }
 
     internal fun administrate(): JiraAdministrationMenu {
+        NotificationPopUps(driver).waitUntilAuiFlagsAreGone()
         driver.findElement(By.id("admin_menu")).click()
         val menu = driver.findElement(By.id("system-admin-menu-content"))
         return JiraAdministrationMenu(driver, menu)


### PR DESCRIPTION
Flags on top of the menu made the setup action to fails.