### PR TITLE
JPERF-1091 Move to the tab panel button before clicking it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        jira-version: ["7.2.0", "7.13.0", "8.0.0", "8.5.0", "8.13.0", "8.20.0", "9.0.0"]
+        jira-version: ["7.2.0", "7.13.0", "8.0.0", "8.5.0", "8.13.0", "8.20.0", "9.0.0", "9.8.0"]
     env:
       JIRA_SOFTWARE_VERSION: ${{ matrix.jira-version }}
     steps:
@@ -25,13 +25,11 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Cache Gradle
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle
-        key: ${{ runner.os }}-${{ hashFiles('gradle') }}
     - name: Build
-      run: ./gradlew build
+      uses: gradle/gradle-build-action@v2
+      with:
+        gradle-version: wrapper
+        arguments: build
     - name: Upload test reports
       if: always()
       uses: actions/upload-artifact@v2
@@ -61,11 +59,6 @@ jobs:
       uses: actions/checkout@v2
       with:
         fetch-depth: 0
-    - name: Cache Gradle
-      uses: actions/cache@v2
-      with:
-        path: ~/.gradle
-        key: ${{ runner.os }}-${{ hashFiles('gradle') }}
     - name: Get publish token
       id: publish-token
       uses: atlassian-labs/artifact-publish-token@v1.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,7 +29,7 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Fixed
 - Fix listing issue keys on list view. Fix [JPERF-1098].
 - Counteract seed bias.
-- Fix switching Activity Tabs on Jira 9.8.0. Fix [JPERF-1091].
+- Switch to Activity Tabs despite sticky comments footer (introduced in Jira 9.8.0). Fix [JPERF-1091].
 
 [JPERF-1098]: https://ecosystem.atlassian.net/browse/JPERF-1098
 [JPERF-1091]: https://ecosystem.atlassian.net/browse/JPERF-1091

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,8 +29,10 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ### Fixed
 - Fix listing issue keys on list view. Fix [JPERF-1098].
 - Counteract seed bias.
+- Fix switching Activity Tabs on Jira 9.8.0. Fix [JPERF-1091].
 
 [JPERF-1098]: https://ecosystem.atlassian.net/browse/JPERF-1098
+[JPERF-1091]: https://ecosystem.atlassian.net/browse/JPERF-1091
 
 ## [3.20.3]
 [3.20.3]: https://github.com/atlassian/jira-actions/compare/release-3.20.2...release-3.20.3

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/CommentTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/CommentTabPanel.kt
@@ -1,6 +1,7 @@
 package com.atlassian.performance.tools.jiraactions.api.page
 
 import com.atlassian.performance.tools.jiraactions.api.memories.Comment
+import com.atlassian.performance.tools.jiraactions.page.scrollIntoView
 import org.apache.logging.log4j.LogManager
 import org.apache.logging.log4j.Logger
 import org.openqa.selenium.By
@@ -21,10 +22,7 @@ class CommentTabPanel(
     private val attemptLimit = 5
 
     fun waitForActive(): CommentTabPanel {
-        Actions(driver)
-            .moveToElement(driver.findElement(By.id("comment-tabpanel")))
-            .click()
-            .perform()
+        driver.findElement(By.id("comment-tabpanel")).scrollIntoView(driver).click()
         driver.wait(presenceOfElementLocated(By.cssSelector("#comment-tabpanel.active")))
         return this
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/CommentTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/CommentTabPanel.kt
@@ -21,7 +21,10 @@ class CommentTabPanel(
     private val attemptLimit = 5
 
     fun waitForActive(): CommentTabPanel {
-        driver.wait(elementToBeClickable(By.id("comment-tabpanel"))).click()
+        Actions(driver)
+            .moveToElement(driver.findElement(By.id("comment-tabpanel")))
+            .click()
+            .perform()
         driver.wait(presenceOfElementLocated(By.cssSelector("#comment-tabpanel.active")))
         return this
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
@@ -1,5 +1,6 @@
 package com.atlassian.performance.tools.jiraactions.api.page
 
+import com.atlassian.performance.tools.jiraactions.page.scrollIntoView
 import org.openqa.selenium.By
 import org.openqa.selenium.Keys
 import org.openqa.selenium.WebDriver
@@ -24,10 +25,7 @@ class HistoryTabPanel(
     }
 
     fun waitForActive(): HistoryTabPanel {
-        Actions(driver)
-            .moveToElement(driver.findElement(By.id("changehistory-tabpanel")))
-            .click()
-            .perform()
+        driver.findElement(By.id("changehistory-tabpanel")).scrollIntoView(driver).click()
         driver.wait(presenceOfElementLocated(By.cssSelector("#changehistory-tabpanel.active")))
         return this
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/HistoryTabPanel.kt
@@ -4,7 +4,8 @@ import org.openqa.selenium.By
 import org.openqa.selenium.Keys
 import org.openqa.selenium.WebDriver
 import org.openqa.selenium.interactions.Actions
-import org.openqa.selenium.support.ui.ExpectedConditions.*
+import org.openqa.selenium.support.ui.ExpectedConditions.invisibilityOfElementLocated
+import org.openqa.selenium.support.ui.ExpectedConditions.presenceOfElementLocated
 
 class HistoryTabPanel(
     private val driver: WebDriver
@@ -23,7 +24,10 @@ class HistoryTabPanel(
     }
 
     fun waitForActive(): HistoryTabPanel {
-        driver.wait(elementToBeClickable(By.id("changehistory-tabpanel"))).click()
+        Actions(driver)
+            .moveToElement(driver.findElement(By.id("changehistory-tabpanel")))
+            .click()
+            .perform()
         driver.wait(presenceOfElementLocated(By.cssSelector("#changehistory-tabpanel.active")))
         return this
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/WebElementExtension.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/page/WebElementExtension.kt
@@ -1,0 +1,10 @@
+package com.atlassian.performance.tools.jiraactions.page
+
+import org.openqa.selenium.JavascriptExecutor
+import org.openqa.selenium.WebDriver
+import org.openqa.selenium.WebElement
+
+internal fun WebElement.scrollIntoView(driver: WebDriver): WebElement {
+    (driver as JavascriptExecutor).executeScript("arguments[0].scrollIntoView()", this)
+    return this
+}


### PR DESCRIPTION
Move to the tab panel button before clicking it to avoid intercepting clicks by the new sticky comment footer.