### PR TITLE
JPERF-1434: Reuse existing mechanism in WebJira to obtain Jira node id

### DIFF
--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/JiraNodeIdMemory.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/JiraNodeIdMemory.kt
@@ -1,0 +1,13 @@
+package com.atlassian.performance.tools.jiraactions
+
+class JiraNodeIdMemory {
+    private var nodeId: String? = null
+
+    fun rememberNodeId(nodeId: String) {
+        this.nodeId = nodeId
+    }
+
+    fun recallNodeId(): String? {
+        return nodeId
+    }
+}

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/WebJira.kt
@@ -1,5 +1,6 @@
 package com.atlassian.performance.tools.jiraactions.api
 
+import com.atlassian.performance.tools.jiraactions.JiraNodeIdMemory
 import com.atlassian.performance.tools.jiraactions.administration.JiraAdministrationMenu
 import com.atlassian.performance.tools.jiraactions.api.page.*
 import org.openqa.selenium.By
@@ -12,6 +13,7 @@ data class WebJira(
     val base: URI,
     val adminPassword: String
 ) {
+    private val jiraNodeMemory = JiraNodeIdMemory()
 
     fun goToLogin(): LoginPage {
         navigateTo("login.jsp")
@@ -92,6 +94,17 @@ data class WebJira(
     }
 
     fun getJiraNode(): String {
+        return jiraNodeMemory.recallNodeId()
+            ?: (findNodeId()
+                .takeUnless { it.isNullOrBlank() }
+                ?.also { jiraNodeMemory.rememberNodeId(it) })
+            ?: throw Exception("Could not find Jira node ID")
+    }
+
+    /**
+     * Based on [How to determine which node a user is accessing in Datacenter](https://confluence.atlassian.com/jirakb/how-to-determine-which-node-a-user-is-accessing-in-datacenter-885252555.html)
+     */
+    private fun findNodeId(): String? {
         return driver.findElement(By.id("footer-build-information")).text
     }
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/w3c/JavascriptW3cPerformanceTimeline.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/w3c/JavascriptW3cPerformanceTimeline.kt
@@ -4,6 +4,7 @@ import com.atlassian.performance.tools.jiraactions.w3c.harvesters.getJsElementsP
 import com.atlassian.performance.tools.jiraactions.w3c.harvesters.getJsNavigationsPerformance
 import com.atlassian.performance.tools.jiraactions.w3c.harvesters.getJsResourcesPerformance
 import org.openqa.selenium.JavascriptExecutor
+import java.util.function.Supplier
 
 /**
  * Obtains entries from [javascript].
@@ -12,18 +13,22 @@ class JavascriptW3cPerformanceTimeline private constructor(
     private val javascript: JavascriptExecutor,
     private val recordNavigation: Boolean,
     private val recordResources: Boolean,
-    private val recordElements: Boolean
+    private val recordElements: Boolean,
+    private val nodeIdSupplier: Supplier<String?>
 ) : W3cPerformanceTimeline {
 
     @Deprecated("Use JavascriptW3cPerformanceTimeline.Builder instead.")
     constructor(
         javascript: JavascriptExecutor
-    ) : this(javascript, true, true, false)
+    ) : this(javascript, true, true, false, Supplier { null })
 
     override fun record(): RecordedPerformanceEntries {
         return RecordedPerformanceEntries(
-            navigations = if (recordNavigation) getJsNavigationsPerformance(javascript) else emptyList(),
-            resources = if (recordResources) getJsResourcesPerformance(javascript) else emptyList(),
+            navigations = if (recordNavigation) getJsNavigationsPerformance(
+                javascript,
+                nodeIdSupplier
+            ) else emptyList(),
+            resources = if (recordResources) getJsResourcesPerformance(javascript, nodeIdSupplier) else emptyList(),
             elements = if (recordElements) getJsElementsPerformance(javascript) else emptyList()
         )
     }
@@ -34,11 +39,14 @@ class JavascriptW3cPerformanceTimeline private constructor(
         private var recordNavigation = true
         private var recordResources = true
         private var recordElements = false
+        private var nodeIdSupplier: Supplier<String?> = Supplier { null }
 
         fun javascript(javascript: JavascriptExecutor) = apply { this.javascript = javascript }
         fun recordNavigation(recordNavigation: Boolean) = apply { this.recordNavigation = recordNavigation }
         fun recordResources(recordResources: Boolean) = apply { this.recordResources = recordResources }
         fun recordElements(recordElements: Boolean) = apply { this.recordElements = recordElements }
+
+        fun nodeIdSupplier(nodeIdSupplier: Supplier<String?>) = apply { this.nodeIdSupplier = nodeIdSupplier }
         fun recordAll() = apply {
             recordNavigation = true
             recordResources = true
@@ -49,7 +57,8 @@ class JavascriptW3cPerformanceTimeline private constructor(
             javascript = javascript,
             recordNavigation = recordNavigation,
             recordResources = recordResources,
-            recordElements = recordElements
+            recordElements = recordElements,
+            nodeIdSupplier = nodeIdSupplier
         )
     }
 }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/w3c/harvesters/JsNavigations.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/w3c/harvesters/JsNavigations.kt
@@ -3,31 +3,35 @@ package com.atlassian.performance.tools.jiraactions.w3c.harvesters
 import com.atlassian.performance.tools.jiraactions.api.w3c.NavigationType
 import com.atlassian.performance.tools.jiraactions.api.w3c.PerformanceNavigationTiming
 import org.openqa.selenium.JavascriptExecutor
+import java.util.function.Supplier
 
-internal fun getJsNavigationsPerformance(jsExecutor: JavascriptExecutor): List<PerformanceNavigationTiming> {
+internal fun getJsNavigationsPerformance(
+    jsExecutor: JavascriptExecutor,
+    nodeIdSupplier: Supplier<String?>
+): List<PerformanceNavigationTiming> {
     val jsNavigations = jsExecutor.executeScript("return window.performance.getEntriesByType(\"navigation\");")
-    return parseNavigations(jsNavigations, jsExecutor)
+    return parseNavigations(jsNavigations, nodeIdSupplier)
 }
 
 private fun parseNavigations(
     jsNavigations: Any?,
-    jsExecutor: JavascriptExecutor
+    nodeIdSupplier: Supplier<String?>
 ): List<PerformanceNavigationTiming> {
     if (jsNavigations !is List<*>) {
         throw Exception("Unexpected non-list JavaScript value: $jsNavigations")
     }
-    return jsNavigations.map { parsePerformanceNavigationTiming(it, jsExecutor) }
+    return jsNavigations.map { parsePerformanceNavigationTiming(it, nodeIdSupplier) }
 }
 
 private fun parsePerformanceNavigationTiming(
     map: Any?,
-    jsExecutor: JavascriptExecutor
+    nodeIdSupplier: Supplier<String?>
 ): PerformanceNavigationTiming {
     if (map !is Map<*, *>) {
         throw Exception("Unexpected non-map JavaScript value: $map")
     }
     return PerformanceNavigationTiming(
-        resource = parsePerformanceResourceTiming(map, jsExecutor),
+        resource = parsePerformanceResourceTiming(map, nodeIdSupplier),
         unloadEventStart = parseTimestamp(map["unloadEventStart"]),
         unloadEventEnd = parseTimestamp(map["unloadEventEnd"]),
         domInteractive = parseTimestamp(map["domInteractive"]),


### PR DESCRIPTION
Reuse existing mechanism in WebJira to obtain Jira node ID. Store the once-obtained node ID in a memory.

I tested this change with the profiler, showing minimal impact on the test time.