### PR TITLE
JPERF-1435: remove JS header parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,9 @@ Dropping a requirement of a major version of a dependency is a new contract.
   - formalize the dependency on `Server-Timing`s convention (e.g. `response-thread-plugin` public behavioral API)
   - encapsulate a specific `ActionMetric.drilldown` analysis (e.g. navigations are not the only backend interactions)
 
+### Fixed
+- Reduce overhead of `JavascriptW3cPerformanceTimeline`.
+
 ## [3.25.0] - 2023-11-09
 [3.25.0]: https://github.com/atlassian/jira-actions/compare/release-3.24.0...release-3.25.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,10 @@ Adding a requirement of a major version of a dependency is breaking a contract.
 Dropping a requirement of a major version of a dependency is a new contract.
 
 ## [Unreleased]
-[Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.24.0...master
+[Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.25.0...master
+
+## [3.25.0] - 2023-11-09
+[3.25.0]: https://github.com/atlassian/jira-actions/compare/release-3.24.0...release-3.25.0
 
 ### Added
 - Add `ActionMetric.toBackendTimeSlots()`. Aid with [JPERF-1409].

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,11 @@ Dropping a requirement of a major version of a dependency is a new contract.
 ## [Unreleased]
 [Unreleased]: https://github.com/atlassian/jira-actions/compare/release-3.25.0...master
 
+### Deprecated
+- Deprecate `ActionMetric.toBackendTimeSlots`. It belongs to a module, which can:
+  - formalize the dependency on `Server-Timing`s convention (e.g. `response-thread-plugin` public behavioral API)
+  - encapsulate a specific `ActionMetric.drilldown` analysis (e.g. navigations are not the only backend interactions)
+
 ## [3.25.0] - 2023-11-09
 [3.25.0]: https://github.com/atlassian/jira-actions/compare/release-3.24.0...release-3.25.0
 

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/ActionMetric.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/ActionMetric.kt
@@ -31,6 +31,9 @@ data class ActionMetric @Deprecated("Use ActionMetric.Builder instead.") constru
 
     val end: Instant = start + duration
 
+    /**
+     * @since 3.25.0
+     */
     fun toBackendTimeSlots(): List<BackendTimeSlot> {
         return drilldown
             ?.navigations

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/ActionMetric.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/ActionMetric.kt
@@ -34,6 +34,7 @@ data class ActionMetric @Deprecated("Use ActionMetric.Builder instead.") constru
     /**
      * @since 3.25.0
      */
+    @Deprecated("This method is misplaced. It overly relies on details of response-thread-plugin. It also assumes that only navigations matter for backend timeslots.")
     fun toBackendTimeSlots(): List<BackendTimeSlot> {
         return drilldown
             ?.navigations
@@ -53,7 +54,7 @@ data class ActionMetric @Deprecated("Use ActionMetric.Builder instead.") constru
                 ?: throw Exception("No threadId in $this, so we cannot map it to a backend timeslot"),
             nodeId = resource
                 .serverTiming
-                .find { it.name == "nodeId" }
+                .find { it.name == "clusterNodeId" }
                 ?.description
         )
     }

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/BackendTimeSlot.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/BackendTimeSlot.kt
@@ -3,6 +3,9 @@ package com.atlassian.performance.tools.jiraactions.api
 import java.time.Duration
 import java.time.Instant
 
+/**
+ * @since 3.25.0
+ */
 class BackendTimeSlot internal constructor(
     val start: Instant,
     val end: Instant,

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/w3c/harvesters/JsNavigations.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/w3c/harvesters/JsNavigations.kt
@@ -6,28 +6,26 @@ import org.openqa.selenium.JavascriptExecutor
 
 internal fun getJsNavigationsPerformance(jsExecutor: JavascriptExecutor): List<PerformanceNavigationTiming> {
     val jsNavigations = jsExecutor.executeScript("return window.performance.getEntriesByType(\"navigation\");")
-    return parseNavigations(jsNavigations, jsExecutor)
+    return parseNavigations(jsNavigations)
 }
 
 private fun parseNavigations(
-    jsNavigations: Any?,
-    jsExecutor: JavascriptExecutor
+    jsNavigations: Any?
 ): List<PerformanceNavigationTiming> {
     if (jsNavigations !is List<*>) {
         throw Exception("Unexpected non-list JavaScript value: $jsNavigations")
     }
-    return jsNavigations.map { parsePerformanceNavigationTiming(it, jsExecutor) }
+    return jsNavigations.map { parsePerformanceNavigationTiming(it) }
 }
 
 private fun parsePerformanceNavigationTiming(
-    map: Any?,
-    jsExecutor: JavascriptExecutor
+    map: Any?
 ): PerformanceNavigationTiming {
     if (map !is Map<*, *>) {
         throw Exception("Unexpected non-map JavaScript value: $map")
     }
     return PerformanceNavigationTiming(
-        resource = parsePerformanceResourceTiming(map, jsExecutor),
+        resource = parsePerformanceResourceTiming(map),
         unloadEventStart = parseTimestamp(map["unloadEventStart"]),
         unloadEventEnd = parseTimestamp(map["unloadEventEnd"]),
         domInteractive = parseTimestamp(map["domInteractive"]),


### PR DESCRIPTION
For every resource (navigation, XHR, JS, CSS, image), it would send a
new HTTP request to parse headers.

The resource URI was not taken into account in the synthetic request,
so it could not infer original HTTP headers. Especially since the new
request can have different response headers than the original requests.
And even if they had the same, then it means we assume sticky session.
So we might read node id once just as well.

Supposedly, the synthetic request was being read from a cache,
but apparently it's still too much overhead.

We'll have to read the node id from `Server-Timing` header,
which is automatically captured by the browser
and it's the same way we obtain the response thread id.