### PR TITLE
JC-1877 adjust the create issue dialog header accordingly to the product changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,11 @@ jobs:
     steps:
     - name: Checkout
       uses: actions/checkout@v4
+    - name: Set up Java 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
     - name: Build
@@ -53,6 +58,11 @@ jobs:
     - name: Get publish token
       id: publish-token
       uses: atlassian-labs/artifact-publish-token@v1.0.1
+    - name: Set up Java 8
+      uses: actions/setup-java@v3
+      with:
+        java-version: '8'
+        distribution: 'temurin'
     - name: Release
       env:
         atlassian_private_username: ${{ steps.publish-token.outputs.artifactoryUsername }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     - name: Setup Gradle
       uses: gradle/actions/setup-gradle@v3
     - name: Build
-      run: ./gradlew build
+      run: ./gradlew build --stacktrace --info
     - name: Upload diagnoses
       if: always()
       uses: actions/upload-artifact@v4

--- a/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
+++ b/src/main/kotlin/com/atlassian/performance/tools/jiraactions/api/page/IssueCreateDialog.kt
@@ -126,7 +126,7 @@ class IssueCreateDialog(
     }
 
     private fun dismissConfigureFieldsDialog() {
-        driver.wait(elementToBeClickable(By.xpath("//*[@id='create-issue-dialog']//h2"))).click()
+        driver.wait(elementToBeClickable(By.xpath("//*[@id='create-issue-dialog']//*[self::h1 or self::h2]"))).click()
     }
 
     fun fillRequiredFields(): IssueCreateDialog {


### PR DESCRIPTION
Since Jira 10.7.0, the header for the `Create Issue` dialog has changed from `<h2>` to `<h1>`, according to the A11y guidelines. 

The `create issue` action was failing since 10.7.0, because it couldn't find the header to move out of the configuring fields dropdown. After the change, both the new `<h1>` header and the legacy `<h2>` are supported. 